### PR TITLE
Notifier: clear tooltip if no update is available

### DIFF
--- a/notifier/octopi-notifier/mainwindow.cpp
+++ b/notifier/octopi-notifier/mainwindow.cpp
@@ -219,6 +219,7 @@ void MainWindow::refreshAppIcon()
   {
     //m_systemTrayIcon->setToolTip(StrConstants::getApplicationName());
     m_actionOctopi->setText("Octopi...");
+    m_systemTrayIcon->setToolTip("");
   }
   else if (m_numberOfOutdatedPackages > 0)
   {


### PR DESCRIPTION
If you look carefully, octopi-notifier shows a tooltip about the last number of outdated packages, even after the upgrade conclusion.
This _awesome_ patch clears the system tray tooltip when there is no update available.
