### PR TITLE
Add pkgfile support for listing noninstalled packages content

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -863,6 +863,20 @@ void MainWindow::_closeTabFilesSearchBar()
 }
 
 /*
+ * Extracts the base file name from an absolute file name.
+ */
+QString MainWindow::_extractBaseFileName(const QString &fileName)
+{
+  QString baseFileName(fileName);
+
+  if (fileName.endsWith('/')) {
+    baseFileName.remove(baseFileName.size()-1, 1);
+  }
+
+  return baseFileName.right(baseFileName.size() - baseFileName.lastIndexOf('/') -1);
+}
+
+/*
  * Whenever user double clicks the package list items, app shows the contents of the selected package
  */
 void MainWindow::onDoubleClickPackageList()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -203,6 +203,7 @@ private:
   //Tab Files related methods
   void _closeTabFilesSearchBar();
   void _selectFirstItemOfPkgFileList();
+  QString _extractBaseFileName(const QString &fileName);
   QString getSelectedDirectory();
 
   void initTabFiles();

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -969,10 +969,12 @@ QHash<QString, QString> Package::getYaourtOutdatedPackagesNameVersion()
 /*
  * Retrieves the file list content of the given package
  */
-QStringList Package::getContents(const QString& pkgName)
+QStringList Package::getContents(const QString& pkgName, bool isInstalled)
 {
   QStringList rsl;
-  QByteArray result = UnixCommand::getPackageContents(pkgName);
+  QByteArray result = isInstalled?
+    UnixCommand::getPackageContentsUsingPacman(pkgName):
+    UnixCommand::getPackageContentsUsingPkgfile(pkgName);
 
   QString aux(result);
   rsl = aux.split("\n", QString::SkipEmptyParts);

--- a/src/package.h
+++ b/src/package.h
@@ -139,7 +139,7 @@ class Package{
     static double getDownloadSizeDescription(const QString &pkgName);
     static QString getInformationDescription(const QString &pkgName, bool foreignPackage = false);
     static QHash<QString, QString> getYaourtOutdatedPackagesNameVersion();
-    static QStringList getContents(const QString &pkgName);
+    static QStringList getContents(const QString &pkgName, bool isInstalled);
 
     static QString getVersion(const QString &pkgInfo);
     static QString getRepository(const QString &pkgInfo);

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -284,7 +284,7 @@ QByteArray UnixCommand::getYaourtPackageVersionInformation()
 /*
  * Given a package name, returns a string containing all the files inside it
  */
-QByteArray UnixCommand::getPackageContents(const QString& pkgName)
+QByteArray UnixCommand::getPackageContentsUsingPacman(const QString& pkgName)
 {
   QStringList args;
   args << "-Ql";
@@ -292,6 +292,44 @@ QByteArray UnixCommand::getPackageContents(const QString& pkgName)
 
   QByteArray res = performQuery(args);
   return res;
+}
+
+/*
+ * Check if pkgfile is installed on the system
+ */
+bool UnixCommand::isPkgfileInstalled()
+{
+  QProcess pkgfile;
+
+  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+  pkgfile.setProcessEnvironment(env);
+
+  pkgfile.start("pkgfile -V");
+  pkgfile.waitForFinished();
+
+  return pkgfile.exitStatus() == QProcess::NormalExit;
+}
+
+/*
+ * Given a package name, which can be installed or uninstalled on system
+ * returns a string containing all the files inside it, the file list is
+ * obtained using pkgfile
+ */
+QByteArray UnixCommand::getPackageContentsUsingPkgfile(const QString &pkgName)
+{
+  QByteArray result("");
+  QProcess pkgfile;
+
+  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+  env.insert("LANG", "C");
+  env.insert("LC_MESSAGES", "C");
+  pkgfile.setProcessEnvironment(env);
+
+  pkgfile.start("pkgfile -l " + pkgName);
+  pkgfile.waitForFinished();
+  result = pkgfile.readAllStandardOutput();
+
+  return result;
 }
 
 /*

--- a/src/unixcommand.h
+++ b/src/unixcommand.h
@@ -89,7 +89,10 @@ public:
   static QByteArray getPackageList();
   static QByteArray getPackageInformation(const QString &pkgName, bool foreignPackage);
   static QByteArray getYaourtPackageVersionInformation();
-  static QByteArray getPackageContents(const QString &pkgName);
+  static QByteArray getPackageContentsUsingPacman(const QString &pkgName);
+  static bool isPkgfileInstalled();
+  static QByteArray getPackageContentsUsingPkgfile(const QString &pkgName);
+
   static QByteArray getPackageGroups();
   static QByteArray getPackagesFromGroup(const QString &groupName);
   static QByteArray getTargetUpgradeList(const QString &pkgName = "");


### PR DESCRIPTION
Hello,

This patch adds support for listing content for noninstalled packages using pkgfile. The user will select a noninstalled package from the list, and, if she has pkgfile installed on her system, Octopi will show the package content by executing `pkgfile -l <package>`, otherwise, Octopi will show the message **This package is not installed, to view the content of this package, you need to install "pkgfile"**.

For installed packages, Octopi will still use pacman for retrieve the package content.

This patch is working but I think there are some unimplemented things to take into account:
1. When pkgfile is not installed, the error message should be showed on a more elegant way rather than creating an item for the files treeview to showing it.
2. Octopi should warn user when pkgfile database is out-to-date (for example, 30 hours old) and maybe a button to update pkgfile database on the spot and/or an explanation to configure a scheduled job to update it automatically.

Cheers!
