### PR TITLE
fixed freeze for install orphaned/yaourt package

### DIFF
--- a/src/mainwindow_transaction.cpp
+++ b/src/mainwindow_transaction.cpp
@@ -1544,7 +1544,7 @@ void MainWindow::actionsProcessStarted()
  *
  * ATENTION: ALL CALLS TO buildPackageList were changed to metaBuildPackageList !!!
  */
-void MainWindow::actionsProcessFinished(int exitCode, QProcess::ExitStatus)
+void MainWindow::actionsProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
   bool bRefreshGroups = true;
 
@@ -1552,7 +1552,7 @@ void MainWindow::actionsProcessFinished(int exitCode, QProcess::ExitStatus)
 
   ui->twProperties->setTabText(ctn_TABINDEX_OUTPUT, StrConstants::getTabOutputName());
 
-  if (exitCode == 0){
+  if (exitCode == 0 && exitStatus == QProcess::NormalExit){
     writeToTabOutputExt("<br><b>" +
                      StrConstants::getCommandFinishedOK() + "</b><br>");
   }

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -719,35 +719,38 @@ void UnixCommand::runCommandInTerminalAsNormalUser(const QStringList &commandLis
   out.flush();
   ftemp->close();
 
+  QString cmd;
   if(WMHelper::isXFCERunning() && UnixCommand::hasTheExecutable(ctn_XFCE_TERMINAL)){
-    QString cmd = ctn_XFCE_TERMINAL + " -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+    cmd = ctn_XFCE_TERMINAL + " -e " + ftemp->fileName();
+  }
+  else if (WMHelper::isKDERunning() && UnixCommand::hasTheExecutable(ctn_KDE_TERMINAL))
+  {
+    cmd = ctn_KDE_TERMINAL + " --nofork -e bash -c " + ftemp->fileName();
   }
   else if (WMHelper::isTDERunning() && UnixCommand::hasTheExecutable(ctn_TDE_TERMINAL)){
-    QString cmd = ctn_TDE_TERMINAL + " --nofork -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+    cmd = ctn_TDE_TERMINAL + " --nofork -e " + ftemp->fileName();
   }
   if (WMHelper::isLXDERunning() && UnixCommand::hasTheExecutable(ctn_LXDE_TERMINAL)){
-    QString cmd = ctn_LXDE_TERMINAL + " -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+    cmd = ctn_LXDE_TERMINAL + " -e " + ftemp->fileName();
   }
   else if (WMHelper::isMATERunning() && UnixCommand::hasTheExecutable(ctn_MATE_TERMINAL)){
-    QString cmd = ctn_MATE_TERMINAL + " -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+    cmd = ctn_MATE_TERMINAL + " -e " + ftemp->fileName();
   }
   else if (UnixCommand::hasTheExecutable(ctn_XFCE_TERMINAL)){
-    QString cmd = ctn_XFCE_TERMINAL + " -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+    cmd = ctn_XFCE_TERMINAL + " -e " + ftemp->fileName();
   }
   else if (UnixCommand::hasTheExecutable(ctn_LXDE_TERMINAL)){
-    QString cmd = ctn_LXDE_TERMINAL + " -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+    cmd = ctn_LXDE_TERMINAL + " -e " + ftemp->fileName();
   }
   else if (UnixCommand::hasTheExecutable(ctn_XTERM)){
-    QString cmd = ctn_XTERM +
+    cmd = ctn_XTERM +
         " -fn \"*-fixed-*-*-*-18-*\" -fg White -bg Black -title xterm -e " + ftemp->fileName();
-    m_processWrapper->executeCommand(cmd);
+  } else {
+    std::cerr << "Octopi found no suitable terminal" << std::endl;
+    emit finishedTerminal(0, QProcess::CrashExit);
+    return;
   }
+  m_processWrapper->executeCommand(cmd);
 }
 
 /*


### PR DESCRIPTION
when installing an AUR package (directly) via context menu from the
package list, the group tree would freeze and octopi wouldnt shut down
afterwards. this happened because octopi didnt find a suitable terminal,
but did wait for its execution.
This fix adds "konsole" as terminal for kde and will abort in case no
suitable terminal was found. also the info tab will not indicate
successfull completion in this case.
