### PR TITLE
Fix detection of a running KDE desktop

### DIFF
--- a/src/wmhelper.cpp
+++ b/src/wmhelper.cpp
@@ -47,19 +47,24 @@ bool WMHelper::isKDERunning(){
   {
     QStringList slParam;
     QProcess proc;
-    slParam << "-C";
-    slParam << ctn_KDE_DESKTOP;
-    proc.start("ps", slParam);
-    proc.waitForStarted();
-    proc.waitForFinished();
+    ret = false;
+    QStringList kdeDesktops = QStringList() << ctn_KDE_DESKTOP << ctn_KDE_X11_DESKTOP << ctn_KDE_WAYLAND_DESKTOP;
+    QStringList::const_iterator constIterator;
+    for (constIterator = kdeDesktops.constBegin(); constIterator != kdeDesktops.constEnd(); ++constIterator) {
+      QString desktop = (*constIterator).toLocal8Bit().constData();
+      slParam.clear();
+      slParam << "-C";
+      slParam << desktop;
+      proc.start("ps", slParam);
+      proc.waitForStarted();
+      proc.waitForFinished();
 
-    QString out = proc.readAll();
-    proc.close();
+      QString out = proc.readAll();
+      proc.close();
 
-    if (out.count(ctn_KDE_DESKTOP)>0)
-      ret = true;
-    else
-      ret = false;
+      if (out.count(desktop)>0)
+        ret = true;
+    }
 
     firstTime = false;
   }

--- a/src/wmhelper.h
+++ b/src/wmhelper.h
@@ -27,6 +27,8 @@ const QString ctn_NO_SU_COMMAND("none");
 const QString ctn_ROOT_SH("/bin/sh -c ");
 const QString ctn_KDESU("kdesu");
 const QString ctn_KDE_DESKTOP("kwin");
+const QString ctn_KDE_X11_DESKTOP("kwin_x11");
+const QString ctn_KDE_WAYLAND_DESKTOP("kwin_wayland");
 const QString ctn_KDE_EDITOR("kwrite");
 const QString ctn_KDE_FILE_MANAGER("kfmclient");
 const QString ctn_KDE_TERMINAL("konsole");


### PR DESCRIPTION
-In newer version of kwin the binary is named kwin_x11 or kwin_wayland
