### PR TITLE
BugFix: In Cinnamon, gnome-terminal wasn't handled properly causing Xterm to be used as a fallback.

### DIFF
--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -396,6 +396,10 @@ void Terminal::runCommandInTerminal(const QStringList &commandList)
       QString cmd = suCommand + " \"" + ctn_MATE_TERMINAL + " -e \'bash -c " + ftemp->fileName() + "'\"";
       m_process->start(cmd);
     }
+    else if (WMHelper::isCinnamonRunning() && UnixCommand::hasTheExecutable(ctn_CINNAMON_TERMINAL)){
+      QString cmd = suCommand + " \"" + ctn_CINNAMON_TERMINAL + " -e \'bash -c " + ftemp->fileName() + "'\"";
+      m_process->start(cmd);
+    }
     else if (WMHelper::isLXQTRunning() && UnixCommand::hasTheExecutable(ctn_LXQT_TERMINAL)){
       QString cmd = suCommand + " \"" + ctn_LXQT_TERMINAL + " -e \'bash -c " + ftemp->fileName() + "'\"";
       m_process->start(cmd);
@@ -459,6 +463,10 @@ void Terminal::runCommandInTerminal(const QStringList &commandList)
     }
     else if (m_selectedTerminal == ctn_MATE_TERMINAL){
       QString cmd = suCommand + " \"" + ctn_MATE_TERMINAL + " -e \'bash -c " + ftemp->fileName() + "'\"";
+      m_process->start(cmd);
+    }
+    else if (m_selectedTerminal == ctn_CINNAMON_TERMINAL){
+      QString cmd = suCommand + " \"" + ctn_CINNAMON_TERMINAL + " -e \'bash -c " + ftemp->fileName() + "'\"";
       m_process->start(cmd);
     }
     else if (m_selectedTerminal == ctn_LXQT_TERMINAL){
@@ -529,6 +537,9 @@ void Terminal::runCommandInTerminalAsNormalUser(const QStringList &commandList)
     else if (WMHelper::isLXQTRunning() && UnixCommand::hasTheExecutable(ctn_LXQT_TERMINAL)){
       cmd = ctn_LXQT_TERMINAL + " -e bash -c " + ftemp->fileName();
     }
+    else if (WMHelper::isCinnamonRunning() && UnixCommand::hasTheExecutable(ctn_CINNAMON_TERMINAL)){
+      cmd = ctn_CINNAMON_TERMINAL + " -e " + ftemp->fileName();
+    }
     else if (UnixCommand::hasTheExecutable(ctn_PEK_TERMINAL)){
       cmd = ctn_PEK_TERMINAL + " -e " + ftemp->fileName();
     }
@@ -579,6 +590,9 @@ void Terminal::runCommandInTerminalAsNormalUser(const QStringList &commandList)
     }
     else if (m_selectedTerminal == ctn_MATE_TERMINAL){
       cmd = ctn_MATE_TERMINAL + " -e " + ftemp->fileName();
+    }
+    else if (m_selectedTerminal == ctn_CINNAMON_TERMINAL){
+      cmd = ctn_CINNAMON_TERMINAL + " -e " + ftemp->fileName();
     }
     else if (m_selectedTerminal == ctn_LXQT_TERMINAL){
       cmd = ctn_LXQT_TERMINAL + " -e bash -c " + ftemp->fileName();

--- a/src/wmhelper.cpp
+++ b/src/wmhelper.cpp
@@ -207,7 +207,7 @@ bool WMHelper::isMATERunning(){
 bool WMHelper::isCinnamonRunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-C";
+  slParam << "-fC";
   slParam << ctn_CINNAMON_DESKTOP;
 
   proc.start("ps", slParam);

--- a/src/wmhelper.h
+++ b/src/wmhelper.h
@@ -77,7 +77,7 @@ const QString ctn_MATE_EDITOR("mate-open");
 const QString ctn_MATE_FILE_MANAGER("caja");
 const QString ctn_MATE_TERMINAL("mate-terminal");
 
-const QString ctn_CINNAMON_DESKTOP("gnome-session");
+const QString ctn_CINNAMON_DESKTOP("cinnamon-session");
 const QString ctn_CINNAMON_EDITOR("gedit");
 const QString ctn_CINNAMON_FILE_MANAGER("nemo");
 const QString ctn_CINNAMON_TERMINAL("gnome-terminal");


### PR DESCRIPTION
I've made various changes to properly support Cinnamon.
- Cinnamon session shows as cinnamon-session and not as gnome-session
- ps -C cinnamon-session gives "PID TTY TIME CMD\n 627 ? 00:00:00 **cinnamon-sessio**\n". The name is truncated so the -f option needs to be used.
 