### PR TITLE
Fix aarnt/octopi#117 same version number of outdated/available package

### DIFF
--- a/src/package.cpp
+++ b/src/package.cpp
@@ -1131,9 +1131,9 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
         QString pkgName = nameVersion.at(0);
 
         //Let's ignore the "IgnorePkg" list of packages...
-        if (!ignorePkgList.contains(pkgName))
+        if (!ignorePkgList.contains(pkgName) && nameVersion.size() > 3)
         {
-          hash.insert(pkgName, nameVersion.at(1));
+            hash.insert(pkgName, nameVersion.at(3));
         }
       }
     }


### PR DESCRIPTION
The issue was occurring with yaourt. A wrong index number was taken when parsing the output of yaourt -Qua.