### PR TITLE
Octopi notifier: improve integration into LXQt

### DIFF
--- a/octopi-notifier.desktop
+++ b/octopi-notifier.desktop
@@ -7,3 +7,4 @@ Type=Application
 Categories=GNOME;GTK;System;
 #NotShowIn=GNOME;XFCE;LXDE;KDE;
 StartupNotify=true
+X-LXQt-Need-Tray=true


### PR DESCRIPTION
The additional key in `octopi-notifier.desktop` proposed by this PR is needed to make Octopi notifier work reliably in plugin-statusnotifier which is implementing KSNI in LXQt.
As such it's obviously geared towards this particular desktop environment only but as it's using prefix `X-*` as [described](http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s11.html) in the underlying [Desktop Entry Specification](http://standards.freedesktop.org/desktop-entry-spec/latest/) no downside has to be expected.