### PR TITLE
Replace ccr with chaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ makepkg -f
 ### How to enable the "alien" icon at toolbar
 
 To enable AUR support, you'll need to install "yaourt" or "pacaur" in your system.  
-In Chakra, "ccr" will be supported out of the box.  
+In Chakra, "chaser" will be supported out of the box.  
 In KaOS, "kcp" will be supported out of the box.
 
 ### Ways to help/support Octopi

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -623,7 +623,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       //Chakra does not have popularity support in CCR
       QString aurTool = StrConstants::getForeignRepositoryToolName();
 
-      if (aurTool != "ccr" && aurTool != "pacaur" && strVotes.count() > 0)
+      if (aurTool != "chaser" && aurTool != "pacaur" && strVotes.count() > 0)
       {
         if (!strVotes.first().isEmpty())
           pkgVotes = strVotes.first().replace('(', "").replace(')', "").toInt();

--- a/src/pacmanexec.cpp
+++ b/src/pacmanexec.cpp
@@ -902,9 +902,10 @@ void PacmanExec::doAURInstall(const QString &listOfPackages)
     m_lastCommandList.append(StrConstants::getForeignRepositoryToolName() + " -i " + listOfPackages + ";");
   else if (StrConstants::getForeignRepositoryToolName() == "pacaur")
     m_lastCommandList.append(StrConstants::getForeignRepositoryToolName() + " -Sa " + listOfPackages + ";");
-  else if (StrConstants::getForeignRepositoryToolName() == "yaourt" ||
-           StrConstants::getForeignRepositoryToolName() == "ccr")
+  else if (StrConstants::getForeignRepositoryToolName() == "yaourt")
     m_lastCommandList.append(StrConstants::getForeignRepositoryToolName() + " -S " + listOfPackages + ";");
+  else if (StrConstants::getForeignRepositoryToolName() == "chaser")
+    m_lastCommandList.append(StrConstants::getForeignRepositoryToolName() + " install " + listOfPackages + ";");
 
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
@@ -920,7 +921,7 @@ void PacmanExec::doAURRemove(const QString &listOfPackages)
 {
   m_lastCommandList.clear();
 
-  if (StrConstants::getForeignRepositoryToolName() == "ccr" ||
+  if (StrConstants::getForeignRepositoryToolName() == "chaser" ||
       StrConstants::getForeignRepositoryToolName() == "kcp")
   {
     m_lastCommandList.append("pacman -R " + listOfPackages + ";");

--- a/src/strconstants.h
+++ b/src/strconstants.h
@@ -85,7 +85,7 @@ public:
     if (first)
     {
       if( UnixCommand::getLinuxDistro() == ectn_CHAKRA )
-        ret = QLatin1String( "ccr" );
+        ret = QLatin1String( "chaser" );
       else if (UnixCommand::getLinuxDistro() == ectn_KAOS)
         ret = QLatin1String( "kcp" );
       else if (UnixCommand::hasTheExecutable("pacaur"))

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -209,8 +209,8 @@ QByteArray UnixCommand::getAURUrl(const QString &pkgName)
 
   aur.setProcessEnvironment(env);
 
-  if (StrConstants::getForeignRepositoryToolName() == "ccr")
-    aur.start(StrConstants::getForeignRepositoryToolName() + " -Si " + pkgName);
+  if (StrConstants::getForeignRepositoryToolName() == "chaser")
+    aur.start(StrConstants::getForeignRepositoryToolName() + " info " + pkgName);
   else
     aur.start(StrConstants::getForeignRepositoryToolName() + " -Sia " + pkgName);
 
@@ -238,6 +238,8 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
   {
     if (StrConstants::getForeignRepositoryToolName() == "yaourt")
       aur.start(StrConstants::getForeignRepositoryToolName() + " --nocolor -Ss " + searchString);
+    else if (StrConstants::getForeignRepositoryToolName() == "chaser")
+      aur.start(StrConstants::getForeignRepositoryToolName() + " search " + searchString);
     else
       aur.start(StrConstants::getForeignRepositoryToolName() + " -Ss " + searchString);
   }
@@ -254,6 +256,18 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
     res.remove("[1;32m");
     res.remove("[1;34m");
     res.remove("[1;36m");
+
+    return res.toLatin1();
+  }
+  else if (UnixCommand::getLinuxDistro() == ectn_CHAKRA)
+  {
+    QString res = result;
+    res.remove("\033");
+    res.remove("[0m");
+    res.remove("[1m");
+    res.remove("[m");
+    res.remove("[32m");
+    res.remove("[35m");
 
     return res.toLatin1();
   }


### PR DESCRIPTION
This PR replaces `ccr` with `chaser` for Chakra. I've tested it locally, but let me know if you see any problems.