### PR TITLE
Update source with the new address for Chakra

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, 10 Linux distros are compatible with it
  * [ArchBang] (http://wiki.archbang.org/index.php?title=Main_Page)
  * [Arch] (https://www.archlinux.org/)
  * [ArchBSD] (https://pacbsd.org/)
- * [Chakra] (https://chakraos.org/)
+ * [Chakra] (https://chakralinux.org/)
  * [KaOS] (http://kaosx.us/)
  * [Manjaro] (http://manjaro.github.io/)
  * [mooOS] (http://mooos.org/)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -279,7 +279,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
   const QString ctn_ANTERGOS_RSS_URL = "http://antergos.com/category/news/feed/";
   const QString ctn_ARCHBSD_RSS_URL = "http://archbsd.net/feeds/news/";
   const QString ctn_ARCH_LINUX_RSS_URL = "https://www.archlinux.org/feeds/news/";
-  const QString ctn_CHAKRA_RSS_URL = "https://chakraos.org/news/index.php?/feeds/index.rss2";
+  const QString ctn_CHAKRA_RSS_URL = "https://chakralinux.org/news/index.php?/feeds/index.rss2";
   const QString ctn_KAOS_RSS_URL = "https://kaosx.us/feed.xml";
   const QString ctn_MANJARO_LINUX_RSS_URL = "https://manjaro.org/feed/";
   //const QString ctn_MANJARO_LINUX_RSS_URL = "https://manjaro.github.io/feed.xml";


### PR DESCRIPTION
Chakra has changed its address from chakraos.org to chakralinux.org. These commits should reflect the change.