### PR TITLE
Change font family from "sansserif" to "Sans Serif"

### DIFF
--- a/src/searchlineedit.cpp
+++ b/src/searchlineedit.cpp
@@ -120,7 +120,7 @@ QString SearchLineEdit::styleSheetForCurrentState()
 
   if (/*this->text().isEmpty() && */ (UnixCommand::getLinuxDistro() != ectn_CHAKRA))
   {
-    style += "font-family: 'sansserif';";
+    style += "font-family: 'Sans Serif';";
     style += "font-style: italic;";
   }
   else
@@ -154,7 +154,7 @@ void SearchLineEdit::setFoundStyle(){
 
   if (UnixCommand::getLinuxDistro() != ectn_CHAKRA)
   {
-    style += "font-family: 'sansserif';";
+    style += "font-family: 'Sans Serif';";
     style += "font-style: italic;";
     style += "padding-left: 20px;";
     style += QString("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + 2);
@@ -184,7 +184,7 @@ void SearchLineEdit::setNotFoundStyle(){
 
   if (UnixCommand::getLinuxDistro() != ectn_CHAKRA)
   {
-    style += "font-family: 'sansserif';";
+    style += "font-family: 'Sans Serif';";
     style += "font-style: italic;";
     style += "padding-left: 20px;";
     style += QString("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + 2);


### PR DESCRIPTION
Issue #222: Font family "sansserif" creates a conflict with Microsoft's font "SansSerif" if installed. Qt is unable to draw this font because of a bad cmap table. Aliases and substitutions by using fontconfig don't work, only blacklisting. Working formats include "sans serif" and "sans-serif". I went with "Sans Serif" to stay coherent with the patch applied by Manjaro Team.