### PR TITLE
BugFix: no outdated AUR packages detected

### DIFF
--- a/src/package.cpp
+++ b/src/package.cpp
@@ -1556,9 +1556,6 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
         }
         else //It's yaourt!
         {
-          if (!pkgName.startsWith(StrConstants::getForeignRepositoryTargetPrefix()))
-            continue;
-
           //Let's ignore the "IgnorePkg" list of packages...
           if (!ignorePkgList.contains(pkgName))
           {


### PR DESCRIPTION
To fix https://github.com/aarnt/octopi/issues/235
Removed lines always executed because StrConstants::getForeignRepositoryTargetPrefix() had been already deleted from pkgName.