### PR TITLE
Update utils.cpp with the new address for the Chakra RSS feed

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -276,7 +276,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
   const QString ctn_ANTERGOS_RSS_URL = "http://antergos.com/category/news/feed/";
   const QString ctn_ARCHBSD_RSS_URL = "http://archbsd.net/feeds/news/";
   const QString ctn_ARCH_LINUX_RSS_URL = "https://www.archlinux.org/feeds/news/";
-  const QString ctn_CHAKRA_RSS_URL = "https://chakralinux.org/news/index.php?/feeds/index.rss2";
+  const QString ctn_CHAKRA_RSS_URL = "https://community.chakralinux.org/c/news.rss";
   const QString ctn_KAOS_RSS_URL = "https://kaosx.us/feed.xml";
   const QString ctn_MANJARO_LINUX_RSS_URL = "https://manjaro.org/feed/";
   //const QString ctn_MANJARO_LINUX_RSS_URL = "https://manjaro.github.io/feed.xml";


### PR DESCRIPTION
Chakra has changed its address for news to `community.chakralinux.org/c/news.rss`. This commit should reflect the change.