### PR TITLE
Handle multiple IgnorePkg/IgnoreGroup statements

### DIFF
--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -1076,7 +1076,7 @@ QStringList UnixCommand::getFieldFromPacmanConf(const QString &fieldName)
 
         ignorePkg = ignorePkg.mid(equal+1, newLine-(equal+1)).trimmed();
         result += ignorePkg.split(QRegularExpression("\\s+"), QString::SkipEmptyParts);
-        from = newLine;
+        from = end + newLine;
       }
       else if (str != "#")
         from += end + ctn_FIELD_LENGTH;

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -1075,8 +1075,8 @@ QStringList UnixCommand::getFieldFromPacmanConf(const QString &fieldName)
         int newLine = ignorePkg.indexOf("\n");
 
         ignorePkg = ignorePkg.mid(equal+1, newLine-(equal+1)).trimmed();
-        result = ignorePkg.split(QRegularExpression("\\s+"), QString::SkipEmptyParts);
-        break;
+        result += ignorePkg.split(QRegularExpression("\\s+"), QString::SkipEmptyParts);
+        from = newLine;
       }
       else if (str != "#")
         from += end + ctn_FIELD_LENGTH;


### PR DESCRIPTION
Fix for https://github.com/aarnt/octopi/issues/309
Search all `IgnorePkg`/`IgnoreGroup` statements in `pacman.conf`.