### PR TITLE
Enable HiDPI icons

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,8 @@
 
 int main(int argc, char *argv[])
 {
+  QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+
   ArgumentList *argList = new ArgumentList(argc, argv);
   QString packagesToInstall;
   QString arg;


### PR DESCRIPTION
Make use of HiDPI icons when scaling is used.