### PR TITLE
Fix typo in PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -31,7 +31,7 @@ build() {
    make
    
    cd octopihelper
-   qmake-qt5 QMAKE_CFLAGS_RELEASE="${CFLAGS}" QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}" QMAKE_LFLAGS_RELEASE="${LDFLAGS}" octopihelper.pro
+   qmake-qt5 QMAKE_CFLAGS_RELEASE="${CFLAGS}" QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}" QMAKE_LFLAGS_RELEASE="${LDFLAGS}" octopi-helper.pro
    make
    cd ..
 


### PR DESCRIPTION
The correct filename is https://github.com/aarnt/octopi/blob/master/octopihelper/octopi-helper.pro