### PR TITLE
octopihelper: fix install path

### DIFF
--- a/octopihelper/octopi-helper.pro
+++ b/octopihelper/octopi-helper.pro
@@ -24,6 +24,15 @@ HEADERS += \
     ../src/argumentlist.h \
     octopihelper.h
 
+# install
+isEmpty(PREFIX) {
+    PREFIX = /usr
+}
+ 
+isEmpty(LIBDIR) {
+    LIBDIR = $$PREFIX/lib
+}
+
 target.path = $$LIBDIR/octopi
 sources.files = $$SOURCES $$HEADERS *.pro
 sources.path = .


### PR DESCRIPTION
Without those rules `octopi-helper` is installed to `/octopi` root dir.

@aarnt 