### PR TITLE
Set desktop file name

### DIFF
--- a/notifier/main.cpp
+++ b/notifier/main.cpp
@@ -68,6 +68,8 @@ int main(int argc, char *argv[])
   MainWindow w;
   QResource::registerResource("./resources.qrc");
 
+  QGuiApplication::setDesktopFileName("octopi-notifier");
+
   if (debugInfo)
     w.turnDebugInfoOn();
 


### PR DESCRIPTION
This allows Plasma to use the application icon in the notifications
![Screenshot_20190903_002919](https://user-images.githubusercontent.com/6377822/64134767-e08a3380-cde1-11e9-9101-b0fc7cc3aa38.png)
