### PR TITLE
Don't use chained QString::arg() calls

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -285,7 +285,7 @@ bool installTempYayHelper()
   QString removeLN = "rm %1";
   QString htmlLatestYay="latestYay.html";
   QString octopiConfDir = QDir::homePath() + QDir::separator() + ".config/octopi";
-  curl=curl.arg(url).arg(octopiConfDir + QDir::separator() + htmlLatestYay);
+  curl=curl.arg(url, octopiConfDir + QDir::separator() + htmlLatestYay);
 
   QProcess p;
   //First we download latest html page of yay-bin at github.com
@@ -318,11 +318,11 @@ bool installTempYayHelper()
 
   //Let's download latest version of yay-bin tarball
   curl = "curl -L %1 --output %2";
-  curl=curl.arg(yayUrl).arg(octopiConfDir + QDir::separator() + yayTarball);
+  curl=curl.arg(yayUrl, octopiConfDir + QDir::separator() + yayTarball);
   p.execute(curl);
 
   //Then we extract binary from tarball
-  tar = tar.arg(octopiConfDir + QDir::separator() + yayTarball).arg(octopiConfDir).arg(yayFile);
+  tar = tar.arg(octopiConfDir + QDir::separator() + yayTarball, octopiConfDir, yayFile);
   p.execute(tar);
 
   //Now we must symlink yay file to octopiConfDir/yay
@@ -330,7 +330,7 @@ bool installTempYayHelper()
   if (QFile::exists(octopiConfDir + QDir::separator() + "yay")) p.execute(removeLN);
 
   //Now we must symlink yay file to octopiConfDir/yayFile/yay
-  ln = ln.arg(octopiConfDir + QDir::separator() + yayFile).arg(octopiConfDir + QDir::separator() + "yay");
+  ln = ln.arg(octopiConfDir + QDir::separator() + yayFile, octopiConfDir + QDir::separator() + "yay");
   p.execute(ln);
 
   //Remove tarball

--- a/src/strconstants.cpp
+++ b/src/strconstants.cpp
@@ -646,7 +646,7 @@ QString StrConstants::getYoullNeedSuFrontend(){
 QString StrConstants::getYoullNeedToInstallAURTool()
 {
   return QObject::tr("You'll need one of those tools to use AUR:\n\n"
-                     "%1, %2, %3 %4 or %5").arg("pacaur").arg("pikaur").arg("trizen").arg("yaourt").arg("yay");
+                     "%1, %2, %3 %4 or %5").arg("pacaur").arg("pikaur", "trizen", "yaourt", "yay");
 }
 
 QString StrConstants::getDoYouWantToInstallYayTool()

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -450,7 +450,7 @@ QByteArray UnixCommand::getExpacInfo(const QString &pkgName, const QString &info
   env.insert("LC_ALL", "C");
   expac.setProcessEnvironment(env);
   QString expacStr = "expac -s \"%%1\" %2";
-  expac.start(expacStr.arg(info).arg(pkgName));
+  expac.start(expacStr.arg(info, pkgName));
   expac.waitForFinished();
   result = expac.readAllStandardOutput();
   expac.close();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -132,40 +132,40 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
 
     /*if (distro == ectn_ENDEAVOUROS || distro == ectn_ANTERGOS)
     {
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }*/
     if (distro == ectn_ARCHLINUX || distro == ectn_ARCHBANGLINUX /*|| distro == ectn_SWAGARCH*/)
     {
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_CHAKRA)
     {
       curlCommand = "curl -k %1 -o %2";
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_CONDRESOS)
     {
       curlCommand = "curl -A \"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0\" -k \"%1\" -o %2";
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_KAOS)
     {
       curlCommand = "curl -k %1 -o %2";
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_MANJAROLINUX)
     {
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     /*else if (distro == ectn_NETRUNNER)
     {
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }*/
     else if (distro == ectn_PARABOLA)
     {
       //Parabola has a certificate which is not "trusted" by default, so we use "curl -k"
       curlCommand = "curl -k %1 -o %2";
-      curlCommand = curlCommand.arg(distroRSSUrl).arg(tmpRssPath);
+      curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
 
     if (UnixCommand::runCurlCommand(curlCommand).isEmpty())


### PR DESCRIPTION
Use the multi-arg overload to save memory allocations.
Found by clazy.