### PR TITLE
Don't use automatic char to QString conversion

### DIFF
--- a/octopi.pro
+++ b/octopi.pro
@@ -7,6 +7,11 @@
 QT += core gui network xml widgets
 #QT += core gui network xml dbus widgets
 DEFINES += OCTOPI_EXTENSIONS ALPM_BACKEND
+
+# Disable automatic string conversions
+DEFINES += QT_USE_QSTRINGBUILDER \
+           QT_NO_CAST_FROM_ASCII
+
 CONFIG += qt warn_on debug link_pkgconfig ALPM_BACKEND
 
 ALPM_BACKEND {

--- a/repoeditor/repoentry.cpp
+++ b/repoeditor/repoentry.cpp
@@ -19,9 +19,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "repoentry.h"
 
-QRegularExpression RepoEntry::nameFilter = QRegularExpression( "" );
-QString RepoEntry::commentString = "";
-QString RepoEntry::repoFormat = "";
+QRegularExpression RepoEntry::nameFilter = QRegularExpression( QLatin1String("") );
+QString RepoEntry::commentString = QLatin1String("");
+QString RepoEntry::repoFormat = QLatin1String("");
 
 RepoEntry::RepoEntry()
     : valid( false )
@@ -39,7 +39,7 @@ RepoEntry::RepoEntry( QString name, bool active )
 QString RepoEntry::getName() const
 {
     if( !nameFilter.isValid() || !isValid() )
-        return "";
+        return QLatin1String("");
 
     QString ret = name;
 
@@ -82,12 +82,12 @@ QString RepoEntry::toString() const
     QStringList list,list2,list3,retList;
 
     if( !isValid() )
-        return "";
+        return QLatin1String("");
 
     if( comments.isEmpty() )
         list << ( active ? name : commentString + name );
     else
-        list << comments.join( "\n" ) << name;
+        list << comments.join( QStringLiteral("\n") ) << name;
 
     if( sigLevelsComments.isEmpty() ) {
         if( !active && !sigLevels.isEmpty() ) {
@@ -97,7 +97,7 @@ QString RepoEntry::toString() const
         } else
             list3 << sigLevels;
     } else
-        list3 << sigLevelsComments.join( "\n" ) << details;
+        list3 << sigLevelsComments.join( QStringLiteral("\n") ) << details;
 
     if( detailsComments.isEmpty() ) {
         if( !active && !details.isEmpty() ) {
@@ -107,13 +107,13 @@ QString RepoEntry::toString() const
         } else
             list2 << details;
     } else
-        list2 << detailsComments.join( "\n" ) << details;
+        list2 << detailsComments.join( QStringLiteral("\n") ) << details;
 
-    retList <<  list.join( QString( "\n" ) + ( active ? "" : commentString ) );
-    retList << list3.join( QString( "\n" ) + ( active ? "" : commentString ) );
-    retList << list2.join( QString( "\n" ) + ( active ? "" : commentString ) );
+    retList <<  list.join( QStringLiteral( "\n" ) + ( active ? QLatin1String("") : commentString ) );
+    retList << list3.join( QStringLiteral( "\n" ) + ( active ? QLatin1String("") : commentString ) );
+    retList << list2.join( QStringLiteral( "\n" ) + ( active ? QLatin1String("") : commentString ) );
 
-    return retList.join( "\n" );
+    return retList.join( QStringLiteral("\n") );
 }
 
 void RepoEntry::setRealName( const QString &realName )

--- a/repoeditor/repoentry.h
+++ b/repoeditor/repoentry.h
@@ -48,7 +48,7 @@ public:
 
     static QString formatRepoName( const QString & name ) {
         QString aux = repoFormat;
-        return aux.replace("%repo%",name);
+        return aux.replace(QLatin1String("%repo%"),name);
     }
 
     QString getName() const; //returns the unformatted repo name

--- a/src/QtSolutions/qtlocalpeer.cpp
+++ b/src/QtSolutions/qtlocalpeer.cpp
@@ -77,12 +77,12 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
 #endif
         prefix = id.section(QLatin1Char('/'), -1);
     }
-    prefix.remove(QRegularExpression("[^a-zA-Z]"));
+    prefix.remove(QRegularExpression(QStringLiteral("[^a-zA-Z]")));
     prefix.truncate(6);
 
     QByteArray idc = id.toUtf8();
     quint16 idNum = qChecksum(idc.constData(), idc.size());
-    socketName = QLatin1String("qtsingleapp-") + prefix
+    socketName = QStringLiteral("qtsingleapp-") + prefix
                  + QLatin1Char('-') + QString::number(idNum, 16);
 
 #if defined(Q_OS_WIN)
@@ -102,7 +102,7 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
     server = new QLocalServer(this);
     QString lockName = QDir(QDir::tempPath()).absolutePath()
                        + QLatin1Char('/') + socketName
-                       + QLatin1String("-lockfile");
+                       + QStringLiteral("-lockfile");
     lockFile.setFileName(lockName);
     lockFile.open(QIODevice::ReadWrite);
 }

--- a/src/QtSolutions/qtsingleapplication.cpp
+++ b/src/QtSolutions/qtsingleapplication.cpp
@@ -430,7 +430,7 @@ void QtSingleApplication::activateWindow(const QString &message)
 
 #else
 
-  if (actWin && message == "RAISE") {
+  if (actWin && message == QLatin1String("RAISE")) {
         actWin->setWindowState(actWin->windowState() & ~Qt::WindowMinimized);
         actWin->raise();
         if (actWin->isHidden())
@@ -438,7 +438,7 @@ void QtSingleApplication::activateWindow(const QString &message)
         else
           actWin->activateWindow();
     }
-  else if (actWin && message == "HIDE") {
+  else if (actWin && message == QLatin1String("HIDE")) {
     if (!actWin->isHidden())
       actWin->hide();
     else
@@ -449,7 +449,7 @@ void QtSingleApplication::activateWindow(const QString &message)
         actWin->show();
     }
   }
-  else if (actWin && message == "CLOSE") {
+  else if (actWin && message == QLatin1String("CLOSE")) {
     if (!actWin->close())
     {
       if (actWin->isHidden())

--- a/src/QtSolutions/qtsingleapplication.cpp
+++ b/src/QtSolutions/qtsingleapplication.cpp
@@ -322,7 +322,7 @@ QWidget* QtSingleApplication::activationWindow() const
 void QtSingleApplication::activateWindow(const QString &message)
 {
 #ifdef OCTOPI_EXTENSIONS
-  if (actWin && message == "RAISE") {
+  if (actWin && message == QLatin1String("RAISE")) {
         actWin->setWindowState(actWin->windowState() & ~Qt::WindowMinimized);
         actWin->raise();
         if (actWin->isHidden())
@@ -330,7 +330,7 @@ void QtSingleApplication::activateWindow(const QString &message)
         else
           actWin->activateWindow();
     }
-  else if (actWin && message == "HIDE") {
+  else if (actWin && message == QLatin1String("HIDE")) {
     if (!actWin->isHidden())
       actWin->hide();
     else
@@ -341,7 +341,7 @@ void QtSingleApplication::activateWindow(const QString &message)
         actWin->show();
     }
   }
-  else if (actWin && message == "SHOW") {
+  else if (actWin && message == QLatin1String("SHOW")) {
     if (actWin->isHidden()){
       actWin->setWindowState(actWin->windowState() & ~Qt::WindowMinimized);
       actWin->raise();
@@ -349,7 +349,7 @@ void QtSingleApplication::activateWindow(const QString &message)
         actWin->show();
     }
   }
-  else if (actWin && message == "OPTIONS") {
+  else if (actWin && message == QLatin1String("OPTIONS")) {
     if (actWin->isHidden()){
       actWin->setWindowState(actWin->windowState() & ~Qt::WindowMinimized);
       actWin->raise();
@@ -362,8 +362,8 @@ void QtSingleApplication::activateWindow(const QString &message)
       mw->onOptions();
     }
   }
-  else if (actWin && ((message == "AURUPGRADE") || (message == "SYSUPGRADE") ||
-                      (message == "SYSUPGRADE_NOCONFIRM")))
+  else if (actWin && ((message == QLatin1String("AURUPGRADE")) || (message == QLatin1String("SYSUPGRADE")) ||
+                      (message == QLatin1String("SYSUPGRADE_NOCONFIRM"))))
   {
     actWin->setWindowState(actWin->windowState() & ~Qt::WindowMinimized);
     actWin->raise();
@@ -378,11 +378,11 @@ void QtSingleApplication::activateWindow(const QString &message)
     {
       if (!mw->isExecutingCommand())
       {
-        if (message == "AURUPGRADE")
+        if (message == QLatin1String("AURUPGRADE"))
         {
           mw->doAURUpgrade();
         }
-        else if (message == "SYSUPGRADE")
+        else if (message == QLatin1String("SYSUPGRADE"))
         {
           mw->doSystemUpgrade();
         }
@@ -393,7 +393,7 @@ void QtSingleApplication::activateWindow(const QString &message)
       }
     }
   }
-  else if (actWin && message == "CLOSE") {
+  else if (actWin && message == QLatin1String("CLOSE")) {
     if (!actWin->close())
     {
       if (actWin->isHidden())
@@ -405,7 +405,7 @@ void QtSingleApplication::activateWindow(const QString &message)
       }
     }
   }
-  else if (actWin && (message.contains("pkg.tar.xz") || (message.contains("pkg.tar.zst")))) {
+  else if (actWin && (message.contains(QLatin1String("pkg.tar.xz")) || (message.contains(QLatin1String("pkg.tar.zst"))))) {
     actWin->setWindowState(actWin->windowState() & ~Qt::WindowMinimized);
     actWin->raise();
     if (actWin->isHidden())
@@ -414,7 +414,7 @@ void QtSingleApplication::activateWindow(const QString &message)
       actWin->activateWindow();
 
     QStringList packagesToInstallList =
-        message.split(",", QString::SkipEmptyParts);
+        message.split(QLatin1Char(','), QString::SkipEmptyParts);
 
     MainWindow *mw = qobject_cast<MainWindow *>(actWin);
 

--- a/src/alpmbackend.cpp
+++ b/src/alpmbackend.cpp
@@ -75,7 +75,7 @@ QStringList AlpmBackend::getPackageList()
 
     if (instPkg)
     {
-      bInstalled = "i";
+      bInstalled = QStringLiteral("i");
       installedVersion = alpm_pkg_get_version(instPkg);
 
       if (!strcmp(repoVersion, installedVersion))
@@ -84,12 +84,12 @@ QStringList AlpmBackend::getPackageList()
       }
       else
       {
-        bInstalled = "o";
+        bInstalled = QStringLiteral("o");
       }
     }
     else
     {
-      bInstalled = "n";
+      bInstalled = QStringLiteral("n");
       installedVersion = "same_version";
     }
 

--- a/src/alpmbackend.cpp
+++ b/src/alpmbackend.cpp
@@ -98,12 +98,12 @@ QStringList AlpmBackend::getPackageList()
 
     std::sprintf(size, "%ld", pkgSize);
 
-    line = bInstalled + " " + dbname + " " +
-           pkgName + " " + repoVersion + " " +
-           installedVersion + " " + QString(size);
+    line = bInstalled + QLatin1Char(' ') + QString::fromUtf8(dbname) + QLatin1Char(' ') +
+           QString::fromUtf8(pkgName) + QLatin1Char(' ') + QString::fromUtf8(repoVersion) + QLatin1Char(' ') +
+           QString::fromUtf8(installedVersion) + QLatin1Char(' ') + QString::fromUtf8(size);
 
     res.append(line);
-    line = "\t" + QString(alpm_pkg_get_desc(pkg));
+    line = QLatin1Char('\t') + QString::fromUtf8(alpm_pkg_get_desc(pkg));
     res.append(line);
   }
 
@@ -135,7 +135,7 @@ QStringList AlpmBackend::getUnrequiredList()
   {
     alpm_pkg_t* pkg = (alpm_pkg_t*) i->data;
     pkgName = alpm_pkg_get_name(pkg),
-    res.append(QString(pkgName));
+    res.append(QString::fromUtf8(pkgName));
   }
 
   // free
@@ -168,10 +168,10 @@ QStringList AlpmBackend::getForeignList()
   {
     alpm_pkg_t* pkg = (alpm_pkg_t*) i->data;
     const char* pkgName = alpm_pkg_get_name(pkg);
-    version = alpm_pkg_get_version(pkg);
-    description = alpm_pkg_get_desc(pkg);
+    version = QString::fromUtf8(alpm_pkg_get_version(pkg));
+    description = QString::fromUtf8(alpm_pkg_get_desc(pkg));
 
-    line = QString(pkgName) + "<o'o>" + QString(version) + "<o'o>" + QString(description);
+    line = QString::fromUtf8(pkgName) + QLatin1String("<o'o>") + QString(version) + QLatin1String("<o'o>") + QString(description);
 
     res.append(line);
   }
@@ -204,7 +204,7 @@ QStringList AlpmBackend::getOutdatedList()
   {
     alpm_pkg_t* pkg = (alpm_pkg_t*) i->data;
     pkgName = alpm_pkg_get_name(pkg),
-    res.append(QString(pkgName));
+    res.append(QString::fromUtf8(pkgName));
   }
 
   // free
@@ -250,7 +250,7 @@ QString AlpmBackend::getPackageSize(const QString &pkgName)
   alpm_utils_free (alpm_utils); // this will free all alpm_pkgs but not the alpm_list
   alpm_list_free (founds);
 
-  return QString(size);
+  return QString::fromUtf8(size);
 }
 
 /*

--- a/src/argumentlist.cpp
+++ b/src/argumentlist.cpp
@@ -13,7 +13,7 @@ ArgumentList::ArgumentList() {
 
 void ArgumentList::argsToStringlist(int argc, char * argv []) {
     for (int i=0; i < argc; ++i) {
-        *this += argv[i];
+        *this += QString::fromLocal8Bit(argv[i]);
     }
 }
 

--- a/src/aurvote.cpp
+++ b/src/aurvote.cpp
@@ -65,7 +65,7 @@ bool AurVote::login()
   postData.addQueryItem(QStringLiteral("remember_me"), QStringLiteral("on"));
 
   QNetworkRequest request(m_loginUrl);
-  request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
+  request.setHeader(QNetworkRequest::ContentTypeHeader,QStringLiteral("application/x-www-form-urlencoded"));
 
   QNetworkReply *r = m_networkManager->post(request, postData.query().toUtf8());
   connect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()) );
@@ -82,7 +82,7 @@ bool AurVote::login()
     eventLoop.exec();
     disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()) );
 
-    QString res = r->readAll();
+    QString res = QString::fromUtf8(r->readAll());
 
     if (res.contains(QLatin1String("Logout")))
     {
@@ -98,13 +98,13 @@ bool AurVote::isLoggedIn()
   bool ret = false;
   QEventLoop eventLoop;
   QNetworkRequest request(m_loginUrl);
-  request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
+  request.setHeader(QNetworkRequest::ContentTypeHeader,QStringLiteral("application/x-www-form-urlencoded"));
   QNetworkReply *r = m_networkManager->get(request);
   connect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()) );
   eventLoop.exec();
   disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()) );
 
-  QString res = r->readAll();
+  QString res = QString::fromUtf8(r->readAll());
 
   if (res.contains(QLatin1String("Logout")))
   {
@@ -128,13 +128,13 @@ int AurVote::isPkgVoted(const QString &pkgName)
   int ret = 0;
   QEventLoop eventLoop;
   QNetworkRequest request(m_pkgUrl.arg(pkgName));
-  request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
+  request.setHeader(QNetworkRequest::ContentTypeHeader,QStringLiteral("application/x-www-form-urlencoded"));
   QNetworkReply *r = m_networkManager->get(request);
   connect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
   eventLoop.exec();
   disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
 
-  QString res = r->readAll();
+  QString res = QString::fromUtf8(r->readAll());
 
   //If this package does not exist anymore...
   QRegularExpression re(QStringLiteral("Page Not Found"));
@@ -153,14 +153,14 @@ void AurVote::voteForPkg(const QString &pkgName)
 {
   QEventLoop eventLoop;
   QNetworkRequest request(m_pkgUrl.arg(pkgName));
-  request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
+  request.setHeader(QNetworkRequest::ContentTypeHeader,QStringLiteral("application/x-www-form-urlencoded"));
   QNetworkReply *r = m_networkManager->get(request);
   connect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
   eventLoop.exec();
   disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
   QString token;
 
-  QString res = r->readAll();
+  QString res = QString::fromUtf8(r->readAll());
 
   //Get token
   QRegularExpression re(QStringLiteral("name=\"token\" value=\"(?<token>\\w+)\""));
@@ -190,14 +190,14 @@ void AurVote::unvoteForPkg(const QString &pkgName)
 {
   QEventLoop eventLoop;
   QNetworkRequest request(m_pkgUrl.arg(pkgName));
-  request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
+  request.setHeader(QNetworkRequest::ContentTypeHeader,QStringLiteral("application/x-www-form-urlencoded"));
   QNetworkReply *r = m_networkManager->get(request);
   connect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
   eventLoop.exec();
   disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
   QString token;
 
-  QString res = r->readAll();
+  QString res = QString::fromUtf8(r->readAll());
 
   //Get token
   QRegularExpression re(QStringLiteral("name=\"token\" value=\"(?<token>\\w+)\""));
@@ -231,13 +231,13 @@ QStringList AurVote::getVotedPackages()
   QString searchUrl=QStringLiteral("https://aur.archlinux.org/packages/?O=0&SeB=nd&SB=w&SO=d&PP=250&do_Search=Go");
   QEventLoop eventLoop;
   QNetworkRequest request(searchUrl);
-  request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
+  request.setHeader(QNetworkRequest::ContentTypeHeader,QStringLiteral("application/x-www-form-urlencoded"));
   QNetworkReply *r = m_networkManager->get(request);
   connect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
   eventLoop.exec();
   disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
 
-  QString res = r->readAll();
+  QString res = QString::fromUtf8(r->readAll());
   res = res.remove(QRegularExpression(QStringLiteral("\\t")));
   res = res.remove(QRegularExpression(QStringLiteral("\\n")));
 

--- a/src/aurvote.cpp
+++ b/src/aurvote.cpp
@@ -30,10 +30,10 @@
  */
 
 AurVote::AurVote(QObject *parent) : QObject(parent),
-  m_loginUrl("https://aur.archlinux.org/login/"),
-  m_voteUrl("https://aur.archlinux.org/pkgbase/%1/vote/"),
-  m_unvoteUrl("https://aur.archlinux.org/pkgbase/%1/unvote/"),
-  m_pkgUrl("https://aur.archlinux.org/packages/%1/")
+  m_loginUrl(QStringLiteral("https://aur.archlinux.org/login/")),
+  m_voteUrl(QStringLiteral("https://aur.archlinux.org/pkgbase/%1/vote/")),
+  m_unvoteUrl(QStringLiteral("https://aur.archlinux.org/pkgbase/%1/unvote/")),
+  m_pkgUrl(QStringLiteral("https://aur.archlinux.org/packages/%1/"))
 {
   m_networkManager = new QNetworkAccessManager(this);
 }
@@ -60,9 +60,9 @@ bool AurVote::login()
   if (m_userName.isEmpty() || m_password.isEmpty()) return false;
 
   QUrlQuery postData;
-  postData.addQueryItem("user", m_userName);
-  postData.addQueryItem("passwd", m_password);
-  postData.addQueryItem("remember_me", "on");
+  postData.addQueryItem(QStringLiteral("user"), m_userName);
+  postData.addQueryItem(QStringLiteral("passwd"), m_password);
+  postData.addQueryItem(QStringLiteral("remember_me"), QStringLiteral("on"));
 
   QNetworkRequest request(m_loginUrl);
   request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
@@ -84,7 +84,7 @@ bool AurVote::login()
 
     QString res = r->readAll();
 
-    if (res.contains("Logout"))
+    if (res.contains(QLatin1String("Logout")))
     {
       ret = true;
     }
@@ -106,7 +106,7 @@ bool AurVote::isLoggedIn()
 
   QString res = r->readAll();
 
-  if (res.contains("Logout"))
+  if (res.contains(QLatin1String("Logout")))
   {
     ret = true;
   }
@@ -137,10 +137,10 @@ int AurVote::isPkgVoted(const QString &pkgName)
   QString res = r->readAll();
 
   //If this package does not exist anymore...
-  QRegularExpression re("Page Not Found");
+  QRegularExpression re(QStringLiteral("Page Not Found"));
   if (res.contains(re)) return -1;
 
-  QRegularExpression re1("name=\"do_Vote\" value=\"Vote for this package\"");
+  QRegularExpression re1(QStringLiteral("name=\"do_Vote\" value=\"Vote for this package\""));
   if (res.contains(re1))
   {
     ret = 1;
@@ -163,20 +163,20 @@ void AurVote::voteForPkg(const QString &pkgName)
   QString res = r->readAll();
 
   //Get token
-  QRegularExpression re("name=\"token\" value=\"(?<token>\\w+)\"");
+  QRegularExpression re(QStringLiteral("name=\"token\" value=\"(?<token>\\w+)\""));
   QRegularExpressionMatch rem;
   if (res.contains(re, &rem))
   {
-    token = rem.captured("token");
+    token = rem.captured(QStringLiteral("token"));
   }
 
-  QRegularExpression re1("name=\"do_Vote\" value=\"Vote for this package\"");
+  QRegularExpression re1(QStringLiteral("name=\"do_Vote\" value=\"Vote for this package\""));
   if (res.contains(re1))
   {
     QUrlQuery postData;
     postData.clear();
-    postData.addQueryItem("token", token);
-    postData.addQueryItem("do_Vote", "Vote+for+this+package");
+    postData.addQueryItem(QStringLiteral("token"), token);
+    postData.addQueryItem(QStringLiteral("do_Vote"), QStringLiteral("Vote+for+this+package"));
 
     request.setUrl(m_unvoteUrl.arg(pkgName));
     r = m_networkManager->post(request, postData.query().toUtf8());
@@ -200,20 +200,20 @@ void AurVote::unvoteForPkg(const QString &pkgName)
   QString res = r->readAll();
 
   //Get token
-  QRegularExpression re("name=\"token\" value=\"(?<token>\\w+)\"");
+  QRegularExpression re(QStringLiteral("name=\"token\" value=\"(?<token>\\w+)\""));
   QRegularExpressionMatch rem;
   if (res.contains(re, &rem))
   {
-    token = rem.captured("token");
+    token = rem.captured(QStringLiteral("token"));
   }
 
-  QRegularExpression re1("name=\"do_UnVote\" value=\"Remove vote\"");
+  QRegularExpression re1(QStringLiteral("name=\"do_UnVote\" value=\"Remove vote\""));
   if (res.contains(re1))
   {
     QUrlQuery postData;
     postData.clear();
-    postData.addQueryItem("token", token);
-    postData.addQueryItem("do_UnVote", "Remove+vote");
+    postData.addQueryItem(QStringLiteral("token"), token);
+    postData.addQueryItem(QStringLiteral("do_UnVote"), QStringLiteral("Remove+vote"));
 
     request.setUrl(m_unvoteUrl.arg(pkgName));
     r = m_networkManager->post(request, postData.query().toUtf8());
@@ -228,7 +228,7 @@ void AurVote::unvoteForPkg(const QString &pkgName)
  */
 QStringList AurVote::getVotedPackages()
 {
-  QString searchUrl="https://aur.archlinux.org/packages/?O=0&SeB=nd&SB=w&SO=d&PP=250&do_Search=Go";
+  QString searchUrl=QStringLiteral("https://aur.archlinux.org/packages/?O=0&SeB=nd&SB=w&SO=d&PP=250&do_Search=Go");
   QEventLoop eventLoop;
   QNetworkRequest request(searchUrl);
   request.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
@@ -238,25 +238,25 @@ QStringList AurVote::getVotedPackages()
   disconnect(r, SIGNAL(finished()), &eventLoop, SLOT(quit()));
 
   QString res = r->readAll();
-  res = res.remove(QRegularExpression("\\t"));
-  res = res.remove(QRegularExpression("\\n"));
+  res = res.remove(QRegularExpression(QStringLiteral("\\t")));
+  res = res.remove(QRegularExpression(QStringLiteral("\\n")));
 
-  QString packageToSearch="<td><a href=\"/packages/(.*)/\">(?<pkgName>\\S+)</a></td>";
-  QString blockToSearch="<tr class=\"(odd|even)\">(.*)</tr>";
+  QString packageToSearch=QStringLiteral("<td><a href=\"/packages/(.*)/\">(?<pkgName>\\S+)</a></td>");
+  QString blockToSearch=QStringLiteral("<tr class=\"(odd|even)\">(.*)</tr>");
   QRegularExpression re(blockToSearch);
   QStringList votedPackages;
 
-  QStringList rows = res.split(QRegularExpression("<tr class=\"(even|odd)\">"));
+  QStringList rows = res.split(QRegularExpression(QStringLiteral("<tr class=\"(even|odd)\">")));
   foreach(QString row, rows)
   {
-    if (row.contains("<td>Yes</td>"))
+    if (row.contains(QLatin1String("<td>Yes</td>")))
     {
       QRegularExpression re(packageToSearch);
       QRegularExpressionMatch rem;
 
       if (row.contains(re, &rem))
       {
-        QString votedPackage = rem.captured("pkgName");
+        QString votedPackage = rem.captured(QStringLiteral("pkgName"));
         votedPackages << votedPackage;
       }
     }

--- a/src/constants.h
+++ b/src/constants.h
@@ -137,7 +137,7 @@ const QString ctn_KEY_REPO_EDITOR_WINDOW_SIZE(QStringLiteral("Repo_Editor_Window
 const QString ctn_PACMAN_SUP_COMMAND = QStringLiteral("pacman --print-format \"%n %v %s\" -Spu");
 
 //Package related
-const QString ctn_TEMP_ACTIONS_FILE ( QDir::tempPath() + QDir::separator() + ".qt_temp_octopi_" );
+const QString ctn_TEMP_ACTIONS_FILE ( QDir::tempPath() + QDir::separator() + QLatin1String(".qt_temp_octopi_") );
 const QString ctn_PACMAN_DATABASE_DIR = QStringLiteral("/var/lib/pacman");
 const QString ctn_PACMAN_DATABASE_LOCK_FILE(QStringLiteral("/var/lib/pacman/db.lck"));
 const QString ctn_PACMAN_CORE_DB_FILE = QStringLiteral("/var/lib/pacman/sync/core.db");

--- a/src/constants.h
+++ b/src/constants.h
@@ -32,10 +32,10 @@
 enum SystemUpgradeOptions { ectn_NO_OPT, ectn_SYNC_DATABASE_OPT, ectn_NOCONFIRM_OPT };
 
 //UnixCommand related
-const QString ctn_MIRROR_CHECK_APP("mirror-check");
+const QString ctn_MIRROR_CHECK_APP(QStringLiteral("mirror-check"));
 
 const QString ctn_OCTOPI_COPYRIGHT =
-    "/*"
+    QLatin1String("/*"
     "* This file is part of Octopi, an open-source GUI for pacman."
     "* Copyright (C) 2013 Alexandre Albuquerque Arnt"
     "*"
@@ -53,7 +53,7 @@ const QString ctn_OCTOPI_COPYRIGHT =
     "* along with this program; if not, write to the Free Software"
     "* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA"
     "*"
-    "*/";
+    "*/");
 
 enum CommandExecuting { ectn_NONE, ectn_CHECK_UPDATES, ectn_MIRROR_CHECK,
                         ectn_SYNC_DATABASE, ectn_SYSTEM_UPGRADE, ectn_INSTALL, ectn_REMOVE,
@@ -75,72 +75,72 @@ enum TreatURLLinks { ectn_TREAT_URL_LINK, ectn_DONT_TREAT_URL_LINK };
 enum SaveSettingsReason { ectn_AUR_PACKAGELIST, ectn_PACKAGELIST, ectn_CURRENTTABINDEX, ectn_NORMAL=30,
                           ectn_MAXIMIZE_PACKAGES=40, ectn_MAXIMIZE_PROPERTIES=50, ectn_GROUPS=5, ectn_CONSOLE_FONT_SIZE };
 
-const QString ctn_ORGANIZATION("octopi");
-const QString ctn_APPLICATION("octopi");
-const QString ctn_KEY_SHOW_PACKAGE_NUMBERS_OUTPUT("Show_Package_Numbers_Output");
-const QString ctn_KEY_ENABLE_TRANSACTION_DIALOG_IN_SYSTEM_UPGRADE("Enable_Transaction_Dialog_In_System_Upgrade");
-const QString ctn_KEY_ENABLE_INTERNET_CHECKING("Enable_Internet_Checking");
-const QString ctn_KEY_SHOW_STOP_TRANSACTION("Show_Stop_Transaction");
-const QString ctn_KEY_AUR_TOOL("Aur_Tool_Name");
-const QString ctn_KEY_AUR_NO_CONFIRM_PARAM("Aur_No_Confirm_Param");
-const QString ctn_KEY_AUR_NO_EDIT_PARAM("Aur_No_Edit_Param");
-const QString ctn_KEY_SEARCH_OUTDATED_AUR_PACKAGES("Search_Outdated_Aur_Packages");
-const QString ctn_KEY_ENABLE_AUR_VOTING("Enable_Aur_Voting");
-const QString ctn_KEY_AUR_USERNAME("Aur_Username");
-const QString ctn_KEY_AUR_PASSWORD("Aur_Password");
-const QString ctn_KEY_USE_ALTERNATE_ROW_COLOR("Use_Alternate_Row_Color");
-const QString ctn_KEY_CONSOLE_SIZE("Console_Font_Size");
-const QString ctn_KEY_BACKEND("Backend");
-const QString ctn_KEY_CURRENT_TAB_INDEX("Current_Tab_Index");
-const QString ctn_KEY_WINDOW_SIZE("Window_Size");
-const QString ctn_KEY_TRANSACTION_WINDOW_SIZE("Transaction_Window_Size");
-const QString ctn_KEY_OUTPUTDIALOG_WINDOW_SIZE("OutputDialog_Window_Size");
-const QString ctn_KEY_OPTIONALDEPS_WINDOW_SIZE("OptionalDeps_Window_Size");
-const QString ctn_KEY_PANEL_ORGANIZING("Panel_Organizing");
-const QString ctn_KEY_PACKAGE_LIST_ORDERED_COL("PackageList_Ordered_Col");
-const QString ctn_KEY_PACKAGE_LIST_SORT_ORDER("PackageList_Sort_Order");
-const QString ctn_KEY_USE_DEFAULT_APP_ICON("Use_Default_App_Icon");
-const QString ctn_KEY_OCTOPI_BUSY_ICON_PATH("Octopi_Busy_Icon_Path");
-const QString ctn_KEY_OCTOPI_RED_ICON_PATH("Octopi_Red_Icon_Path");
-const QString ctn_KEY_OCTOPI_YELLOW_ICON_PATH("Octopi_Yellow_Icon_Path");
-const QString ctn_KEY_OCTOPI_GREEN_ICON_PATH("Octopi_Green_Icon_Path");
-const QString ctn_KEY_DISTRO_RSS_URL("Distro_RSS_Url");
-const QString ctn_KEY_AUR_PACKAGE_LIST_ORDERED_COL("Aur_PackageList_Ordered_Col");
-const QString ctn_KEY_AUR_PACKAGE_LIST_SORT_ORDER("Aur_PackageList_Sort_Order");
-const QString ctn_KEY_SKIP_MIRRORCHECK_ON_STARTUP("Skip_Mirror_Check_At_Startup");
-const QString ctn_KEY_SPLITTER_HORIZONTAL_STATE("Splitter_Horizontal_State");
-const QString ctn_KEY_SHOW_GROUPS_PANEL("Show_Groups_Panel");
-const QString ctn_KEY_PACKAGE_ICON_COLUMN_WIDTH("Package_Icon_Column_Width");
-const QString ctn_KEY_PACKAGE_NAME_COLUMN_WIDTH("Package_Name_Column_Width");
-const QString ctn_KEY_PACKAGE_VERSION_COLUMN_WIDTH("Package_Version_Column_Width");
-const QString ctn_KEY_PACKAGE_REPOSITORY_COLUMN_WIDTH("Package_Repository_Column_Width");
-const QString ctn_KEY_SU_TOOL("SU_Tool_Name");
-const QString ctn_KEY_TERMINAL("Terminal");
-const QString ctn_KEY_INSTANT_SEARCH("Instant_Search");
-const QString ctn_KEY_PROXY_SETTINGS("Proxy_Settings");
-const QString ctn_AUTOMATIC("automatic");
+const QString ctn_ORGANIZATION(QStringLiteral("octopi"));
+const QString ctn_APPLICATION(QStringLiteral("octopi"));
+const QString ctn_KEY_SHOW_PACKAGE_NUMBERS_OUTPUT(QStringLiteral("Show_Package_Numbers_Output"));
+const QString ctn_KEY_ENABLE_TRANSACTION_DIALOG_IN_SYSTEM_UPGRADE(QStringLiteral("Enable_Transaction_Dialog_In_System_Upgrade"));
+const QString ctn_KEY_ENABLE_INTERNET_CHECKING(QStringLiteral("Enable_Internet_Checking"));
+const QString ctn_KEY_SHOW_STOP_TRANSACTION(QStringLiteral("Show_Stop_Transaction"));
+const QString ctn_KEY_AUR_TOOL(QStringLiteral("Aur_Tool_Name"));
+const QString ctn_KEY_AUR_NO_CONFIRM_PARAM(QStringLiteral("Aur_No_Confirm_Param"));
+const QString ctn_KEY_AUR_NO_EDIT_PARAM(QStringLiteral("Aur_No_Edit_Param"));
+const QString ctn_KEY_SEARCH_OUTDATED_AUR_PACKAGES(QStringLiteral("Search_Outdated_Aur_Packages"));
+const QString ctn_KEY_ENABLE_AUR_VOTING(QStringLiteral("Enable_Aur_Voting"));
+const QString ctn_KEY_AUR_USERNAME(QStringLiteral("Aur_Username"));
+const QString ctn_KEY_AUR_PASSWORD(QStringLiteral("Aur_Password"));
+const QString ctn_KEY_USE_ALTERNATE_ROW_COLOR(QStringLiteral("Use_Alternate_Row_Color"));
+const QString ctn_KEY_CONSOLE_SIZE(QStringLiteral("Console_Font_Size"));
+const QString ctn_KEY_BACKEND(QStringLiteral("Backend"));
+const QString ctn_KEY_CURRENT_TAB_INDEX(QStringLiteral("Current_Tab_Index"));
+const QString ctn_KEY_WINDOW_SIZE(QStringLiteral("Window_Size"));
+const QString ctn_KEY_TRANSACTION_WINDOW_SIZE(QStringLiteral("Transaction_Window_Size"));
+const QString ctn_KEY_OUTPUTDIALOG_WINDOW_SIZE(QStringLiteral("OutputDialog_Window_Size"));
+const QString ctn_KEY_OPTIONALDEPS_WINDOW_SIZE(QStringLiteral("OptionalDeps_Window_Size"));
+const QString ctn_KEY_PANEL_ORGANIZING(QStringLiteral("Panel_Organizing"));
+const QString ctn_KEY_PACKAGE_LIST_ORDERED_COL(QStringLiteral("PackageList_Ordered_Col"));
+const QString ctn_KEY_PACKAGE_LIST_SORT_ORDER(QStringLiteral("PackageList_Sort_Order"));
+const QString ctn_KEY_USE_DEFAULT_APP_ICON(QStringLiteral("Use_Default_App_Icon"));
+const QString ctn_KEY_OCTOPI_BUSY_ICON_PATH(QStringLiteral("Octopi_Busy_Icon_Path"));
+const QString ctn_KEY_OCTOPI_RED_ICON_PATH(QStringLiteral("Octopi_Red_Icon_Path"));
+const QString ctn_KEY_OCTOPI_YELLOW_ICON_PATH(QStringLiteral("Octopi_Yellow_Icon_Path"));
+const QString ctn_KEY_OCTOPI_GREEN_ICON_PATH(QStringLiteral("Octopi_Green_Icon_Path"));
+const QString ctn_KEY_DISTRO_RSS_URL(QStringLiteral("Distro_RSS_Url"));
+const QString ctn_KEY_AUR_PACKAGE_LIST_ORDERED_COL(QStringLiteral("Aur_PackageList_Ordered_Col"));
+const QString ctn_KEY_AUR_PACKAGE_LIST_SORT_ORDER(QStringLiteral("Aur_PackageList_Sort_Order"));
+const QString ctn_KEY_SKIP_MIRRORCHECK_ON_STARTUP(QStringLiteral("Skip_Mirror_Check_At_Startup"));
+const QString ctn_KEY_SPLITTER_HORIZONTAL_STATE(QStringLiteral("Splitter_Horizontal_State"));
+const QString ctn_KEY_SHOW_GROUPS_PANEL(QStringLiteral("Show_Groups_Panel"));
+const QString ctn_KEY_PACKAGE_ICON_COLUMN_WIDTH(QStringLiteral("Package_Icon_Column_Width"));
+const QString ctn_KEY_PACKAGE_NAME_COLUMN_WIDTH(QStringLiteral("Package_Name_Column_Width"));
+const QString ctn_KEY_PACKAGE_VERSION_COLUMN_WIDTH(QStringLiteral("Package_Version_Column_Width"));
+const QString ctn_KEY_PACKAGE_REPOSITORY_COLUMN_WIDTH(QStringLiteral("Package_Repository_Column_Width"));
+const QString ctn_KEY_SU_TOOL(QStringLiteral("SU_Tool_Name"));
+const QString ctn_KEY_TERMINAL(QStringLiteral("Terminal"));
+const QString ctn_KEY_INSTANT_SEARCH(QStringLiteral("Instant_Search"));
+const QString ctn_KEY_PROXY_SETTINGS(QStringLiteral("Proxy_Settings"));
+const QString ctn_AUTOMATIC(QStringLiteral("automatic"));
 
 //SettingsManager - Notifier related
-const QString ctn_KEY_LAST_CHECKUPDATES_TIME("LastCheckUpdatesTime");
-const QString ctn_KEY_CHECKUPDATES_INTERVAL("CheckUpdatesInterval");
-const QString ctn_KEY_CHECKUPDATES_HOUR("CheckUpdatesHour");
+const QString ctn_KEY_LAST_CHECKUPDATES_TIME(QStringLiteral("LastCheckUpdatesTime"));
+const QString ctn_KEY_CHECKUPDATES_INTERVAL(QStringLiteral("CheckUpdatesInterval"));
+const QString ctn_KEY_CHECKUPDATES_HOUR(QStringLiteral("CheckUpdatesHour"));
 
 //SettingsManager - CacheCleaner related
-const QString ctn_KEY_CACHE_CLEANER_WINDOW_SIZE("Cache_Cleaner_Window_Size");
-const QString ctn_KEY_KEEP_NUM_INSTALLED("Keep_Num_Installed");
-const QString ctn_KEY_KEEP_NUM_UNINSTALLED("Keep_Num_Uninstalled");
+const QString ctn_KEY_CACHE_CLEANER_WINDOW_SIZE(QStringLiteral("Cache_Cleaner_Window_Size"));
+const QString ctn_KEY_KEEP_NUM_INSTALLED(QStringLiteral("Keep_Num_Installed"));
+const QString ctn_KEY_KEEP_NUM_UNINSTALLED(QStringLiteral("Keep_Num_Uninstalled"));
 
 //SettingsManager - RepoEditor related
-const QString ctn_KEY_REPO_EDITOR_WINDOW_SIZE("Repo_Editor_Window_Size");
+const QString ctn_KEY_REPO_EDITOR_WINDOW_SIZE(QStringLiteral("Repo_Editor_Window_Size"));
 
 //pacman command to retrieve list of upgradable packages with name, version and size
-const QString ctn_PACMAN_SUP_COMMAND = "pacman --print-format \"%n %v %s\" -Spu";
+const QString ctn_PACMAN_SUP_COMMAND = QStringLiteral("pacman --print-format \"%n %v %s\" -Spu");
 
 //Package related
 const QString ctn_TEMP_ACTIONS_FILE ( QDir::tempPath() + QDir::separator() + ".qt_temp_octopi_" );
-const QString ctn_PACMAN_DATABASE_DIR = "/var/lib/pacman";
-const QString ctn_PACMAN_DATABASE_LOCK_FILE("/var/lib/pacman/db.lck");
-const QString ctn_PACMAN_CORE_DB_FILE = "/var/lib/pacman/sync/core.db";
+const QString ctn_PACMAN_DATABASE_DIR = QStringLiteral("/var/lib/pacman");
+const QString ctn_PACMAN_DATABASE_LOCK_FILE(QStringLiteral("/var/lib/pacman/db.lck"));
+const QString ctn_PACMAN_CORE_DB_FILE = QStringLiteral("/var/lib/pacman/sync/core.db");
 
 enum PackageStatus { ectn_INSTALLED, ectn_NON_INSTALLED, ectn_OUTDATED, ectn_NEWER,
                      ectn_FOREIGN, ectn_FOREIGN_OUTDATED };
@@ -148,108 +148,108 @@ enum PackageStatus { ectn_INSTALLED, ectn_NON_INSTALLED, ectn_OUTDATED, ectn_NEW
 enum ViewOptions { ectn_ALL_PKGS, ectn_INSTALLED_PKGS, ectn_NON_INSTALLED_PKGS };
 
 //Supported AUR user base package tools
-const QString ctn_PACAUR_TOOL("pacaur");
-const QString ctn_PIKAUR_TOOL("pikaur");
-const QString ctn_TRIZEN_TOOL("trizen");
-const QString ctn_YAOURT_TOOL("yaourt");
-const QString ctn_YAY_TOOL("yay");
-const QString ctn_NO_AUR_TOOL("DO_NOT_USE_AUR");
+const QString ctn_PACAUR_TOOL(QStringLiteral("pacaur"));
+const QString ctn_PIKAUR_TOOL(QStringLiteral("pikaur"));
+const QString ctn_TRIZEN_TOOL(QStringLiteral("trizen"));
+const QString ctn_YAOURT_TOOL(QStringLiteral("yaourt"));
+const QString ctn_YAY_TOOL(QStringLiteral("yay"));
+const QString ctn_NO_AUR_TOOL(QStringLiteral("DO_NOT_USE_AUR"));
 
 //KaOS user base package tool
-const QString ctn_KCP_TOOL("kcp");
+const QString ctn_KCP_TOOL(QStringLiteral("kcp"));
 //Chakra user base package tool
-const QString ctn_CHASER_TOOL("chaser");
+const QString ctn_CHASER_TOOL(QStringLiteral("chaser"));
 
 //TransactionDialog related
 const int ctn_RUN_IN_TERMINAL(328);
 
 //WMHelper related
-const QString ctn_NO_SU_COMMAND("none");
-const QString ctn_ROOT_SH("/bin/sh -c ");
+const QString ctn_NO_SU_COMMAND(QStringLiteral("none"));
+const QString ctn_ROOT_SH(QStringLiteral("/bin/sh -c "));
 
-const QString ctn_LXQTSU("lxqt-sudo");
-const QString ctn_OCTOPISUDO("/usr/lib/octopi/octopi-sudo");
+const QString ctn_LXQTSU(QStringLiteral("lxqt-sudo"));
+const QString ctn_OCTOPISUDO(QStringLiteral("/usr/lib/octopi/octopi-sudo"));
 
-const QString ctn_KDESU("kdesu");
-const QString ctn_KDE_DESKTOP("kwin");
-const QString ctn_KDE_X11_DESKTOP("kwin_x11");
-const QString ctn_KDE_WAYLAND_DESKTOP("kwin_wayland");
-const QString ctn_KDE_EDITOR("kwrite");
-const QString ctn_KDE_FILE_MANAGER("kfmclient");
-const QString ctn_KDE_TERMINAL("konsole");
-const QString ctn_KDE4_OPEN("kde-open");
-const QString ctn_KDE5_OPEN("kde-open5");
-const QString ctn_KDE4_FILE_MANAGER("dolphin");
-const QString ctn_KDE4_EDITOR("kate");
+const QString ctn_KDESU(QStringLiteral("kdesu"));
+const QString ctn_KDE_DESKTOP(QStringLiteral("kwin"));
+const QString ctn_KDE_X11_DESKTOP(QStringLiteral("kwin_x11"));
+const QString ctn_KDE_WAYLAND_DESKTOP(QStringLiteral("kwin_wayland"));
+const QString ctn_KDE_EDITOR(QStringLiteral("kwrite"));
+const QString ctn_KDE_FILE_MANAGER(QStringLiteral("kfmclient"));
+const QString ctn_KDE_TERMINAL(QStringLiteral("konsole"));
+const QString ctn_KDE4_OPEN(QStringLiteral("kde-open"));
+const QString ctn_KDE5_OPEN(QStringLiteral("kde-open5"));
+const QString ctn_KDE4_FILE_MANAGER(QStringLiteral("dolphin"));
+const QString ctn_KDE4_EDITOR(QStringLiteral("kate"));
 
-const QString ctn_TDESU("tdesu");
-const QString ctn_TDE_DESKTOP("twin");
-const QString ctn_TDE_EDITOR("kwrite");
-const QString ctn_TDE_FILE_MANAGER("kfmclient");
-const QString ctn_TDE_TERMINAL("konsole");
+const QString ctn_TDESU(QStringLiteral("tdesu"));
+const QString ctn_TDE_DESKTOP(QStringLiteral("twin"));
+const QString ctn_TDE_EDITOR(QStringLiteral("kwrite"));
+const QString ctn_TDE_FILE_MANAGER(QStringLiteral("kfmclient"));
+const QString ctn_TDE_TERMINAL(QStringLiteral("konsole"));
 
-const QString ctn_GKSU_1("/usr/libexec/gksu");
-const QString ctn_GKSU_2("gksu");
+const QString ctn_GKSU_1(QStringLiteral("/usr/libexec/gksu"));
+const QString ctn_GKSU_2(QStringLiteral("gksu"));
 
-const QString ctn_ANTERGOS_FILE_MANAGER("nautilus");
+const QString ctn_ANTERGOS_FILE_MANAGER(QStringLiteral("nautilus"));
 
-const QString ctn_ARCHBANG_EDITOR("medit");
-const QString ctn_ARCHBANG_FILE_MANAGER("spacefm");
+const QString ctn_ARCHBANG_EDITOR(QStringLiteral("medit"));
+const QString ctn_ARCHBANG_FILE_MANAGER(QStringLiteral("spacefm"));
 
-const QString ctn_RXVT_TERMINAL("urxvt");
+const QString ctn_RXVT_TERMINAL(QStringLiteral("urxvt"));
 
-const QString ctn_GNOME_EDITOR("gedit");
-const QString ctn_GNOME_FILE_MANAGER("nautilus");
-const QString ctn_GNOME_TERMINAL("gnome-terminal");
+const QString ctn_GNOME_EDITOR(QStringLiteral("gedit"));
+const QString ctn_GNOME_FILE_MANAGER(QStringLiteral("nautilus"));
+const QString ctn_GNOME_TERMINAL(QStringLiteral("gnome-terminal"));
 
-const QString ctn_XFCE_DESKTOP("xfdesktop");
-const QString ctn_XFCE_EDITOR("mousepad");
-const QString ctn_XFCE_EDITOR_ALT("leafpad");
-const QString ctn_XFCE_FILE_MANAGER("thunar");
-const QString ctn_XFCE_TERMINAL("xfce4-terminal");
+const QString ctn_XFCE_DESKTOP(QStringLiteral("xfdesktop"));
+const QString ctn_XFCE_EDITOR(QStringLiteral("mousepad"));
+const QString ctn_XFCE_EDITOR_ALT(QStringLiteral("leafpad"));
+const QString ctn_XFCE_FILE_MANAGER(QStringLiteral("thunar"));
+const QString ctn_XFCE_TERMINAL(QStringLiteral("xfce4-terminal"));
 
-const QString ctn_OPENBOX_DESKTOP("openbox");
-const QString ctn_LXDE_DESKTOP("lxsession");
-const QString ctn_LXDE_TERMINAL("lxterminal");
-const QString ctn_LXDE_FILE_MANAGER("pcmanfm");
+const QString ctn_OPENBOX_DESKTOP(QStringLiteral("openbox"));
+const QString ctn_LXDE_DESKTOP(QStringLiteral("lxsession"));
+const QString ctn_LXDE_TERMINAL(QStringLiteral("lxterminal"));
+const QString ctn_LXDE_FILE_MANAGER(QStringLiteral("pcmanfm"));
 
-const QString ctn_LUMINA_DESKTOP("lumina-desktop");
-const QString ctn_LUMINA_EDITOR("lumina-textedit");
-const QString ctn_LUMINA_FILE_MANAGER("lumina-fm");
-const QString ctn_LUMINA_OPEN("lumina-open");
+const QString ctn_LUMINA_DESKTOP(QStringLiteral("lumina-desktop"));
+const QString ctn_LUMINA_EDITOR(QStringLiteral("lumina-textedit"));
+const QString ctn_LUMINA_FILE_MANAGER(QStringLiteral("lumina-fm"));
+const QString ctn_LUMINA_OPEN(QStringLiteral("lumina-open"));
 
-const QString ctn_LXQT_DESKTOP("lxqt-session");
-const QString ctn_LXQT_TERMINAL("qterminal");
-const QString ctn_LXQT_FILE_MANAGER("pcmanfm-qt");
-const QString ctn_LXQT_EDITOR("juffed");
+const QString ctn_LXQT_DESKTOP(QStringLiteral("lxqt-session"));
+const QString ctn_LXQT_TERMINAL(QStringLiteral("qterminal"));
+const QString ctn_LXQT_FILE_MANAGER(QStringLiteral("pcmanfm-qt"));
+const QString ctn_LXQT_EDITOR(QStringLiteral("juffed"));
 
-const QString ctn_MATE_DESKTOP("mate-session");
-const QString ctn_MATE_EDITOR("mate-open");
-const QString ctn_MATE_FILE_MANAGER("caja");
-const QString ctn_MATE_TERMINAL("mate-terminal");
+const QString ctn_MATE_DESKTOP(QStringLiteral("mate-session"));
+const QString ctn_MATE_EDITOR(QStringLiteral("mate-open"));
+const QString ctn_MATE_FILE_MANAGER(QStringLiteral("caja"));
+const QString ctn_MATE_TERMINAL(QStringLiteral("mate-terminal"));
 
-const QString ctn_CINNAMON_DESKTOP("cinnamon-session");
-const QString ctn_CINNAMON_EDITOR("gedit");
-const QString ctn_CINNAMON_FILE_MANAGER("nemo");
-const QString ctn_CINNAMON_TERMINAL("gnome-terminal");
+const QString ctn_CINNAMON_DESKTOP(QStringLiteral("cinnamon-session"));
+const QString ctn_CINNAMON_EDITOR(QStringLiteral("gedit"));
+const QString ctn_CINNAMON_FILE_MANAGER(QStringLiteral("nemo"));
+const QString ctn_CINNAMON_TERMINAL(QStringLiteral("gnome-terminal"));
 
-const QString ctn_PEK_TERMINAL("sakura");
-const QString ctn_XTERM("xterm");
-const QString ctn_QTERMWIDGET("qtermwidget5");
+const QString ctn_PEK_TERMINAL(QStringLiteral("sakura"));
+const QString ctn_XTERM(QStringLiteral("xterm"));
+const QString ctn_QTERMWIDGET(QStringLiteral("qtermwidget5"));
 
 enum EditOptions { ectn_EDIT_AS_ROOT, ectn_EDIT_AS_NORMAL_USER };
 
 //Octopi-notifier related  -------------------------------------------------------------------------------
 
-const QString ctn_CHECKUPDATES_BINARY = "/usr/bin/checkupdates";
+const QString ctn_CHECKUPDATES_BINARY = QStringLiteral("/usr/bin/checkupdates");
 //const QString ctn_EXPAC_BINARY = "/usr/bin/expac";
 enum ExecOpt { ectn_NORMAL_EXEC_OPT, ectn_SYSUPGRADE_EXEC_OPT, ectn_SYSUPGRADE_NOCONFIRM_EXEC_OPT, ectn_AUR_UPGRADE_EXEC_OPT };
 
 //Octopi-helper related ----------------------------------------------------------------------------------
 
-const QString ctn_OCTOPI_HELPER_VERSION = "0.10 (dev)";
-const QString ctn_OCTOPI_HELPER_NAME("octphelper");
-const QString ctn_OCTOPI_HELPER_PATH("/usr/lib/octopi/octphelper"); //("/usr/lib/octopi/octopi-helper");
+const QString ctn_OCTOPI_HELPER_VERSION = QStringLiteral("0.10 (dev)");
+const QString ctn_OCTOPI_HELPER_NAME(QStringLiteral("octphelper"));
+const QString ctn_OCTOPI_HELPER_PATH(QStringLiteral("/usr/lib/octopi/octphelper")); //("/usr/lib/octopi/octopi-helper");
 
 const int ctn_NO_TEMP_ACTIONS_FILE(1);
 const int ctn_PACMAN_PROCESS_EXECUTING(2);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -58,7 +58,7 @@ QString showPackageDescription(QString pkgName)
   const PackageRepository::PackageData*const package = mw->getFirstPackageFromRepo(pkgName);
 
   if (package == nullptr) {
-    return "";
+    return QLatin1String("");
   }
 
   bool isForeignPkg = (package->status == ectn_FOREIGN || package->status == ectn_FOREIGN_OUTDATED);
@@ -73,7 +73,7 @@ QString showPackageDescription(QString pkgName)
     else return "";
   }*/
 
-  int space = description.indexOf(" ");
+  int space = description.indexOf(QLatin1String(" "));
   QString desc = description.mid(space+1);
   int size = desc.size();
 
@@ -85,7 +85,7 @@ QString showPackageDescription(QString pkgName)
 
   QString installedSize = Package::getInformationInstalledSize(pkgName, isForeignPkg);
 
-  if (!installedSize.isEmpty() && installedSize != "0.00 Bytes")
+  if (!installedSize.isEmpty() && installedSize != QLatin1String("0.00 Bytes"))
     return desc + " → " + installedSize;
   else
     return desc;
@@ -96,7 +96,7 @@ QString showPackageDescription(QString pkgName)
  */
 QList<PackageListData> * searchPacmanPackages(const QHash<QString, QString> *checkUpdatesOutdatedPackages)
 {
-  return Package::getPackageList("", checkUpdatesOutdatedPackages);
+  return Package::getPackageList(QLatin1String(""), checkUpdatesOutdatedPackages);
 }
 
 /*
@@ -127,7 +127,7 @@ QString searchPacmanPackagesByFile(const QString &file)
     result = UnixCommand::getPackageByFilePath(file);
   }
   else
-    result = "";
+    result = QLatin1String("");
 
   return result;
 }
@@ -264,9 +264,9 @@ QString generateSysInfo(QByteArray contents)
   tempFile->close();
 
   //Assign collected logs (contents) to a 24h ptpb paste lifetime
-  QString ptpb = UnixCommand::getCommandOutput("curl -F sunset=86400 -F c=@- https://ptpb.pw/", tempFile->fileName());
+  QString ptpb = UnixCommand::getCommandOutput(QStringLiteral("curl -F sunset=86400 -F c=@- https://ptpb.pw/"), tempFile->fileName());
   //QString ptpb = UnixCommand::getCommandOutput("curl -F sunset=10 -F c=@- https://ptpb.pw/", tempFile->fileName());
-  ptpb.replace("\n", "\n<br>");
+  ptpb.replace(QLatin1String("\n"), QLatin1String("\n<br>"));
   return ptpb;
 }
 
@@ -278,12 +278,12 @@ QString generateSysInfo(QByteArray contents)
 bool installTempYayHelper()
 {
   bool res=true;
-  QString url="https://github.com/Jguer/yay/releases/latest/";
-  QString curl = "curl -L %1 --output %2";
-  QString tar = "tar xzf %1 -C %2 %3";
-  QString ln = "ln -s %1 %2";
-  QString removeLN = "rm %1";
-  QString htmlLatestYay="latestYay.html";
+  QString url=QStringLiteral("https://github.com/Jguer/yay/releases/latest/");
+  QString curl = QStringLiteral("curl -L %1 --output %2");
+  QString tar = QStringLiteral("tar xzf %1 -C %2 %3");
+  QString ln = QStringLiteral("ln -s %1 %2");
+  QString removeLN = QStringLiteral("rm %1");
+  QString htmlLatestYay=QStringLiteral("latestYay.html");
   QString octopiConfDir = QDir::homePath() + QDir::separator() + ".config/octopi";
   curl=curl.arg(url, octopiConfDir + QDir::separator() + htmlLatestYay);
 
@@ -302,14 +302,14 @@ bool installTempYayHelper()
 
   //We have to find this kind of string:
   //<a href="/Jguer/yay/releases/download/v9.3.1/yay_9.3.1_x86_64.tar.gz"
-  QRegularExpression re("<a href=\"(?<site>\\S+/(?<file>yay\\S+_x86_64.tar.gz))\"");
+  QRegularExpression re(QStringLiteral("<a href=\"(?<site>\\S+/(?<file>yay\\S+_x86_64.tar.gz))\""));
   QRegularExpressionMatch rem;
   if (html.contains(re, &rem))
   {
-    yayUrl = rem.captured("site");
-    yayTarball = rem.captured("file");
+    yayUrl = rem.captured(QStringLiteral("site"));
+    yayTarball = rem.captured(QStringLiteral("file"));
     yayFile = yayTarball + QDir::separator() + "yay";
-    yayFile = yayFile.remove(".tar.gz");
+    yayFile = yayFile.remove(QStringLiteral(".tar.gz"));
     yayUrl = "https://github.com" + yayUrl;
     file.close();
     file.remove();
@@ -317,7 +317,7 @@ bool installTempYayHelper()
   else return false;
 
   //Let's download latest version of yay-bin tarball
-  curl = "curl -L %1 --output %2";
+  curl = QStringLiteral("curl -L %1 --output %2");
   curl=curl.arg(yayUrl, octopiConfDir + QDir::separator() + yayTarball);
   p.execute(curl);
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -80,13 +80,13 @@ QString showPackageDescription(QString pkgName)
   if (desc.size() > 120)
   {
     desc.chop(size - 120);
-    desc = desc + " ...";
+    desc = desc + QLatin1String(" ...");
   }
 
   QString installedSize = Package::getInformationInstalledSize(pkgName, isForeignPkg);
 
   if (!installedSize.isEmpty() && installedSize != QLatin1String("0.00 Bytes"))
-    return desc + " → " + installedSize;
+    return desc + QString::fromUtf8(" → ") + installedSize;
   else
     return desc;
 }
@@ -264,7 +264,7 @@ QString generateSysInfo(QByteArray contents)
   tempFile->close();
 
   //Assign collected logs (contents) to a 24h ptpb paste lifetime
-  QString ptpb = UnixCommand::getCommandOutput(QStringLiteral("curl -F sunset=86400 -F c=@- https://ptpb.pw/"), tempFile->fileName());
+  QString ptpb = QString::fromUtf8(UnixCommand::getCommandOutput(QStringLiteral("curl -F sunset=86400 -F c=@- https://ptpb.pw/"), tempFile->fileName()));
   //QString ptpb = UnixCommand::getCommandOutput("curl -F sunset=10 -F c=@- https://ptpb.pw/", tempFile->fileName());
   ptpb.replace(QLatin1String("\n"), QLatin1String("\n<br>"));
   return ptpb;
@@ -284,7 +284,7 @@ bool installTempYayHelper()
   QString ln = QStringLiteral("ln -s %1 %2");
   QString removeLN = QStringLiteral("rm %1");
   QString htmlLatestYay=QStringLiteral("latestYay.html");
-  QString octopiConfDir = QDir::homePath() + QDir::separator() + ".config/octopi";
+  QString octopiConfDir = QDir::homePath() + QDir::separator() + QLatin1String(".config/octopi");
   curl=curl.arg(url, octopiConfDir + QDir::separator() + htmlLatestYay);
 
   QProcess p;
@@ -295,7 +295,7 @@ bool installTempYayHelper()
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
       return false;
 
-  QString html = file.readAll();
+  QString html = QString::fromUtf8(file.readAll());
   QString yayUrl;
   QString yayTarball;
   QString yayFile;
@@ -308,9 +308,9 @@ bool installTempYayHelper()
   {
     yayUrl = rem.captured(QStringLiteral("site"));
     yayTarball = rem.captured(QStringLiteral("file"));
-    yayFile = yayTarball + QDir::separator() + "yay";
+    yayFile = yayTarball + QDir::separator() + QLatin1String("yay");
     yayFile = yayFile.remove(QStringLiteral(".tar.gz"));
-    yayUrl = "https://github.com" + yayUrl;
+    yayUrl = QLatin1String("https://github.com") + yayUrl;
     file.close();
     file.remove();
   }
@@ -326,11 +326,11 @@ bool installTempYayHelper()
   p.execute(tar);
 
   //Now we must symlink yay file to octopiConfDir/yay
-  removeLN = removeLN.arg(octopiConfDir + QDir::separator() + "yay");
-  if (QFile::exists(octopiConfDir + QDir::separator() + "yay")) p.execute(removeLN);
+  removeLN = removeLN.arg(octopiConfDir + QDir::separator() + QLatin1String("yay"));
+  if (QFile::exists(octopiConfDir + QDir::separator() + QLatin1String("yay"))) p.execute(removeLN);
 
   //Now we must symlink yay file to octopiConfDir/yayFile/yay
-  ln = ln.arg(octopiConfDir + QDir::separator() + yayFile, octopiConfDir + QDir::separator() + "yay");
+  ln = ln.arg(octopiConfDir + QDir::separator() + yayFile, octopiConfDir + QDir::separator() + QLatin1String("yay"));
   p.execute(ln);
 
   //Remove tarball

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,10 +51,10 @@ int main(int argc, char *argv[])
 
   for (int c=1; c<argc; c++)
   {
-    arg = argv[c];
+    arg = QString::fromLocal8Bit(argv[c]);
     if (arg.contains(QRegularExpression(QStringLiteral("pkg.tar.[xz|zst]"))))
     {
-      packagesToInstall += arg + ",";
+      packagesToInstall += arg + QLatin1Char(',');
     }
   }
 
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
   app.sendMessage(QStringLiteral("RAISE"));
 
   QTranslator appTranslator;
-  bool success = appTranslator.load(":/resources/translations/octopi_" +
+  bool success = appTranslator.load(QLatin1String(":/resources/translations/octopi_") +
                      QLocale::system().name());
   if (!success)
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   for (int c=1; c<argc; c++)
   {
     arg = argv[c];
-    if (arg.contains(QRegularExpression("pkg.tar.[xz|zst]")))
+    if (arg.contains(QRegularExpression(QStringLiteral("pkg.tar.[xz|zst]"))))
     {
       packagesToInstall += arg + ",";
     }
@@ -62,33 +62,33 @@ int main(int argc, char *argv[])
 
   if (app.isRunning())
   {
-    if (argList->getSwitch("-aurupgrade"))
+    if (argList->getSwitch(QStringLiteral("-aurupgrade")))
     {
-      app.sendMessage("AURUPGRADE");
+      app.sendMessage(QStringLiteral("AURUPGRADE"));
     }
-    else if (argList->getSwitch("-sysupgrade"))
+    else if (argList->getSwitch(QStringLiteral("-sysupgrade")))
     {
-      app.sendMessage("SYSUPGRADE");
+      app.sendMessage(QStringLiteral("SYSUPGRADE"));
     }
-    else if (argList->getSwitch("-sysupgrade-noconfirm"))
+    else if (argList->getSwitch(QStringLiteral("-sysupgrade-noconfirm")))
     {
-      app.sendMessage("SYSUPGRADE_NOCONFIRM");
+      app.sendMessage(QStringLiteral("SYSUPGRADE_NOCONFIRM"));
     }
-    else if (argList->getSwitch("-close"))
+    else if (argList->getSwitch(QStringLiteral("-close")))
     {
-      app.sendMessage("CLOSE");
+      app.sendMessage(QStringLiteral("CLOSE"));
     }
-    else if (argList->getSwitch("-hide"))
+    else if (argList->getSwitch(QStringLiteral("-hide")))
     {
-      app.sendMessage("HIDE");
+      app.sendMessage(QStringLiteral("HIDE"));
     }
-    else if (argList->getSwitch("-options"))
+    else if (argList->getSwitch(QStringLiteral("-options")))
     {
-      app.sendMessage("OPTIONS");
+      app.sendMessage(QStringLiteral("OPTIONS"));
     }
-    else if (argList->getSwitch("-show"))
+    else if (argList->getSwitch(QStringLiteral("-show")))
     {
-      app.sendMessage("SHOW");
+      app.sendMessage(QStringLiteral("SHOW"));
     }
     else if (!packagesToInstall.isEmpty())
     {
@@ -96,32 +96,32 @@ int main(int argc, char *argv[])
     }
     else
     {
-      app.sendMessage("RAISE");
+      app.sendMessage(QStringLiteral("RAISE"));
     }
 
     return 0;
   }
-  else if (UnixCommand::isAppRunning("octopi", false))
+  else if (UnixCommand::isAppRunning(QStringLiteral("octopi"), false))
     return 0;
 
   //This sends a message just to enable the socket-based QtSingleApplication engine
-  app.sendMessage("RAISE");
+  app.sendMessage(QStringLiteral("RAISE"));
 
   QTranslator appTranslator;
   bool success = appTranslator.load(":/resources/translations/octopi_" +
                      QLocale::system().name());
   if (!success)
   {
-    appTranslator.load(":/resources/translations/octopi_en.qm");
+    appTranslator.load(QStringLiteral(":/resources/translations/octopi_en.qm"));
   }
 
   app.installTranslator(&appTranslator);
 
-  if (argList->getSwitch("-help")){
+  if (argList->getSwitch(QStringLiteral("-help"))){
     std::cout << StrConstants::getApplicationCliHelp().toLatin1().data() << std::endl;
     return(0);
   }
-  else if (argList->getSwitch("-version")){
+  else if (argList->getSwitch(QStringLiteral("-version"))){
     std::cout << "\n" << StrConstants::getApplicationName().toLatin1().data() <<
                  " " << StrConstants::getApplicationVersion().toLatin1().data() << "\n" << std::endl;
     return(0);
@@ -139,16 +139,16 @@ int main(int argc, char *argv[])
     app.setActivationWindow(&w);
     app.setQuitOnLastWindowClosed(false);
 
-    if (argList->getSwitch("-sysupgrade-noconfirm"))
+    if (argList->getSwitch(QStringLiteral("-sysupgrade-noconfirm")))
     {
       w.setCallSystemUpgradeNoConfirm();
     }
-    else if (argList->getSwitch("-sysupgrade"))
+    else if (argList->getSwitch(QStringLiteral("-sysupgrade")))
     {
       w.setCallSystemUpgrade();
     }
 
-    if (argList->getSwitch("-d"))
+    if (argList->getSwitch(QStringLiteral("-d")))
     {
       //If user chooses to switch debug info on...
       w.turnDebugInfoOn();
@@ -157,15 +157,15 @@ int main(int argc, char *argv[])
     if (!packagesToInstall.isEmpty())
     {
       QStringList packagesToInstallList =
-          packagesToInstall.split(",", QString::SkipEmptyParts);
+          packagesToInstall.split(QStringLiteral(","), QString::SkipEmptyParts);
 
       w.setPackagesToInstallList(packagesToInstallList);
     }
 
-    w.setRemoveCommand("Rcs");
+    w.setRemoveCommand(QStringLiteral("Rcs"));
     w.show();
 
-    QResource::registerResource("./resources.qrc");
+    QResource::registerResource(QStringLiteral("./resources.qrc"));
 
     return app.exec();
   }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -599,25 +599,25 @@ void MainWindow::outputOutdatedPackageList()
   {
     QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
     QString anchorBegin = QStringLiteral("anchorBegin");
-    html += "<a id=\"" + anchorBegin + "\"></a>";
+    html += QLatin1String("<a id=\"") + anchorBegin + QLatin1String("\"></a>");
 
     clearTabOutput();
 
     if(m_outdatedStringList->count()==1){
-      html += "<h3>" + StrConstants::getOneOutdatedPackage() + "</h3>";
+      html += QLatin1String("<h3>") + StrConstants::getOneOutdatedPackage() + QLatin1String("</h3>");
     }
     else
     {
-      html += "<h3>" +
-          StrConstants::getOutdatedPackages(m_outdatedStringList->count()) + "</h3>";
+      html += QLatin1String("<h3>") +
+          StrConstants::getOutdatedPackages(m_outdatedStringList->count()) + QLatin1String("</h3>");
     }
 
     html += QLatin1String("<br><table border=\"0\">");
-    html += "<tr><th width=\"25%\" align=\"left\">" + StrConstants::getName() +
-        "</th><th width=\"18%\" align=\"right\">" +
+    html += QLatin1String("<tr><th width=\"25%\" align=\"left\">") + StrConstants::getName() +
+        QLatin1String("</th><th width=\"18%\" align=\"right\">") +
         StrConstants::getOutdatedVersion() +
-        "</th><th width=\"18%\" align=\"right\">" +
-        StrConstants::getAvailableVersion() + "</th></tr>";
+        QLatin1String("</th><th width=\"18%\" align=\"right\">") +
+        StrConstants::getAvailableVersion() + QLatin1String("</th></tr>");
 
     for (int c=0; c < m_outdatedStringList->count(); c++)
     {
@@ -625,11 +625,11 @@ void MainWindow::outputOutdatedPackageList()
       const PackageRepository::PackageData*const package = m_packageRepo.getFirstPackageByName(pkg);
 
       if (package != nullptr) {
-        html += "<tr><td><a href=\"goto:" + pkg + "\">" + pkg +
-            "</td><td align=\"right\"><b><font color=\"#E55451\">" +
+        html += QLatin1String("<tr><td><a href=\"goto:") + pkg + QLatin1String("\">") + pkg +
+            QLatin1String("</td><td align=\"right\"><b><font color=\"#E55451\">") +
             package->outdatedVersion +
-            "</b></font></td><td align=\"right\">" +
-            package->version + "</td></tr>";
+            QLatin1String("</b></font></td><td align=\"right\">") +
+            package->version + QLatin1String("</td></tr>");
       }
     }
 
@@ -649,25 +649,25 @@ void MainWindow::outputOutdatedPackageList()
   else {
     QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
     QString anchorBegin = QStringLiteral("anchorBegin");
-    html += "<a id=\"" + anchorBegin + "\"></a>";
+    html += QLatin1String("<a id=\"") + anchorBegin + QLatin1String("\"></a>");
 
     clearTabOutput();
 
     if(m_outdatedStringList->count()==1){
-      html += "<h3>" + StrConstants::getOneOutdatedPackage() + "</h3>";
+      html += QLatin1String("<h3>") + StrConstants::getOneOutdatedPackage() + QLatin1String("</h3>");
     }
     else
     {
-      html += "<h3>" +
-          StrConstants::getOutdatedPackages(m_outdatedStringList->count()) + "</h3>";
+      html += QLatin1String("<h3>") +
+          StrConstants::getOutdatedPackages(m_outdatedStringList->count()) + QLatin1String("</h3>");
     }
 
     html += QLatin1String("<br><table border=\"0\">");
-    html += "<tr><th width=\"25%\" align=\"left\">" + StrConstants::getName() +
-        "</th><th width=\"18%\" align=\"right\">" +
+    html += QLatin1String("<tr><th width=\"25%\" align=\"left\">") + StrConstants::getName() +
+        QLatin1String("</th><th width=\"18%\" align=\"right\">") +
         StrConstants::getOutdatedVersion() +
-        "</th><th width=\"18%\" align=\"right\">" +
-        StrConstants::getAvailableVersion() + "</th></tr>";
+        QLatin1String("</th><th width=\"18%\" align=\"right\">") +
+        StrConstants::getAvailableVersion() + QLatin1String("</th></tr>");
 
     for (int c=0; c < m_checkupdatesStringList->count(); c++)
     {
@@ -675,11 +675,11 @@ void MainWindow::outputOutdatedPackageList()
       const PackageRepository::PackageData*const package = m_packageRepo.getFirstPackageByName(pkg);
 
       if (package != nullptr) {
-        html += "<tr><td><a href=\"goto:" + pkg + "\">" + pkg +
-            "</td><td align=\"right\"><b><font color=\"#E55451\">" +
+        html += QLatin1String("<tr><td><a href=\"goto:") + pkg + QLatin1String("\">") + pkg +
+            QLatin1String("</td><td align=\"right\"><b><font color=\"#E55451\">") +
             package->outdatedVersion +
-            "</b></font></td><td align=\"right\">" +
-            package->version + "</td></tr>";
+            QLatin1String("</b></font></td><td align=\"right\">") +
+            package->version + QLatin1String("</td></tr>");
       }
     }
 
@@ -708,8 +708,8 @@ void MainWindow::outputAURVotedPackageList()
     clearTabOutput();
     QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
     QString anchorBegin = QStringLiteral("anchorBegin");
-    html += "<a id=\"" + anchorBegin + "\"></a>";
-    html += "<h3>" + StrConstants::getAURVotedPackageList() + "</h3>";
+    html += QLatin1String("<a id=\"") + anchorBegin + QLatin1String("\"></a>");
+    html += QLatin1String("<h3>") + StrConstants::getAURVotedPackageList() + QLatin1String("</h3>");
     writeToTabOutput(html);
     ui->twProperties->setCurrentIndex(ctn_TABINDEX_OUTPUT);
 
@@ -718,7 +718,7 @@ void MainWindow::outputAURVotedPackageList()
     QString list=QStringLiteral("<ul>");
     foreach(QString vote, v)
     {
-      list += "<li>" + vote + "</li>";
+      list += QLatin1String("<li>") + vote + QLatin1String("</li>");
     }
 
     list += QLatin1String("</ul><br>");
@@ -745,25 +745,25 @@ void MainWindow::outputOutdatedAURPackageList()
 
   QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
   QString anchorBegin = QStringLiteral("anchorBegin");
-  html += "<a id=\"" + anchorBegin + "\"></a>";
+  html += QLatin1String("<a id=\"") + anchorBegin + QLatin1String("\"></a>");
 
   clearTabOutput();
 
   if(m_outdatedAURStringList->count()==1){
-    html += "<h3>" + StrConstants::getOneOutdatedPackage() + "</h3>";
+    html += QLatin1String("<h3>") + StrConstants::getOneOutdatedPackage() + QLatin1String("</h3>");
   }
   else
   {
-    html += "<h3>" +
-        StrConstants::getOutdatedPackages(m_outdatedAURStringList->count()) + "</h3>";
+    html += QLatin1String("<h3>") +
+        StrConstants::getOutdatedPackages(m_outdatedAURStringList->count()) + QLatin1String("</h3>");
   }
 
   html += QLatin1String("<br><table border=\"0\">");
-  html += "<tr><th width=\"25%\" align=\"left\">" + StrConstants::getName() +
-      "</th><th width=\"18%\" align=\"right\">" +
+  html += QLatin1String("<tr><th width=\"25%\" align=\"left\">") + StrConstants::getName() +
+      QLatin1String("</th><th width=\"18%\" align=\"right\">") +
       StrConstants::getOutdatedVersion() +
-      "</th><th width=\"18%\" align=\"right\">" +
-      StrConstants::getAvailableVersion() + "</th></tr>";
+      QLatin1String("</th><th width=\"18%\" align=\"right\">") +
+      StrConstants::getAvailableVersion() + QLatin1String("</th></tr>");
 
   for (int c=0; c < m_outdatedAURStringList->count(); c++)
   {
@@ -772,11 +772,11 @@ void MainWindow::outputOutdatedAURPackageList()
     if (package != nullptr) {
       QString availableVersion = m_outdatedAURPackagesNameVersion->value(m_outdatedAURStringList->at(c));
   
-      html += "<tr><td><a href=\"goto:" + pkg + "\">" + pkg +
-          "</td><td align=\"right\"><b><font color=\"#E55451\">" +
+      html += QLatin1String("<tr><td><a href=\"goto:") + pkg + QLatin1String("\">") + pkg +
+          QLatin1String("</td><td align=\"right\"><b><font color=\"#E55451\">") +
           package->version +
-          "</b></font></td><td align=\"right\">" +
-          availableVersion + "</td></tr>";
+          QLatin1String("</b></font></td><td align=\"right\">") +
+          availableVersion + QLatin1String("</td></tr>");
     }
   }
 
@@ -827,7 +827,7 @@ bool MainWindow::isAllGroupsSelected()
 
 bool MainWindow::isAllGroups(const QString& group)
 {
-  return ((group == "<" + StrConstants::getDisplayAllGroups() + ">") && !(m_actionSwitchToAURTool->isChecked()));
+  return ((group == QLatin1String("<") + StrConstants::getDisplayAllGroups() + QLatin1String(">")) && !(m_actionSwitchToAURTool->isChecked()));
 }
 
 /*
@@ -1524,12 +1524,12 @@ QString MainWindow::extractBaseFileName(const QString &fileName)
 {
   QString baseFileName(fileName);
 
-  if (fileName.endsWith('/'))
+  if (fileName.endsWith(QLatin1Char('/')))
   {
     baseFileName.remove(baseFileName.size()-1, 1);
   }
 
-  return baseFileName.right(baseFileName.size() - baseFileName.lastIndexOf('/') -1);
+  return baseFileName.right(baseFileName.size() - baseFileName.lastIndexOf(QLatin1Char('/')) -1);
 }
 
 /*
@@ -1883,7 +1883,7 @@ void MainWindow::openTerminal()
   QString dir = getSelectedDirectory();
   if (!dir.isEmpty())
   {
-    m_console->execute("cd " + dir);
+    m_console->execute(QLatin1String("cd ") + dir);
     ensureTabVisible(ctn_TABINDEX_TERMINAL);
   }
 }
@@ -1911,7 +1911,7 @@ void MainWindow::installLocalPackage()
       QFileDialog::getOpenFileNames(this,
                                     StrConstants::getFileChooserTitle(),
                                     QDir::homePath(),
-                                    StrConstants::getPackages() + " (*.pkg.tar*)");
+                                    StrConstants::getPackages() + QLatin1String(" (*.pkg.tar*)"));
 
   if (m_packagesToInstallList.count() > 0)
     doInstallLocalPackages();
@@ -1984,7 +1984,7 @@ void MainWindow::tvPackagesSelectionChanged(const QItemSelection&, const QItemSe
   const int selected = selection != nullptr ? selection->selectedRows().count() : 0;
 
   QString newMessage = StrConstants::getTotalPackages(m_packageModel->getPackageCount()) +
-      " (" + StrConstants::getSelectedPackages(selected) + ") ";
+      QLatin1String(" (") + StrConstants::getSelectedPackages(selected) + QLatin1String(") ");
 
   QString text;
   int numberOfInstalledPackages = m_packageModel->getInstalledPackagesCount();
@@ -2063,7 +2063,7 @@ void MainWindow::doSysInfo()
   connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
   g_fwCommandToExecute.setFuture(f);
   el.exec();
-  QString hostname = g_fwCommandToExecute.result();
+  QString hostname = QString::fromUtf8(g_fwCommandToExecute.result());
 
   hostname.remove(QStringLiteral("\n"));
   QString homePath = QDir::homePath();
@@ -2253,7 +2253,7 @@ void MainWindow::doSysInfo()
 
   m_commandExecuting = ectn_NONE;
   quint32 gen = QRandomGenerator::global()->generate();
-  QString fileName = homePath + QDir::separator() + "octopi-sysinfo-" + QString::number(gen) + ".log";
+  QString fileName = homePath + QDir::separator() + QLatin1String("octopi-sysinfo-") + QString::number(gen) + QLatin1String(".log");
   QFile *outFile = new QFile(fileName);
   outFile->open(QIODevice::ReadWrite|QIODevice::Text);
   outFile->setPermissions(QFile::Permissions(QFile::ExeOwner|QFile::ReadOwner));
@@ -2261,8 +2261,8 @@ void MainWindow::doSysInfo()
   outFile->flush();
   outFile->close();
 
-  writeToTabOutput("<br>" + StrConstants::getSysInfoGenerated().arg(fileName) + "<br>");
-  writeToTabOutput("<br><b>" + StrConstants::getCommandFinishedOK() + "</b><br>");
+  writeToTabOutput(QLatin1String("<br>") + StrConstants::getSysInfoGenerated().arg(fileName) + QLatin1String("<br>"));
+  writeToTabOutput(QLatin1String("<br><b>") + StrConstants::getCommandFinishedOK() + QLatin1String("</b><br>"));
   enableTransactionActions();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,14 +80,14 @@ MainWindow::MainWindow(QWidget *parent) :
   m_outdatedAURStringList = new QStringList();
   m_outdatedAURPackagesNameVersion = new QHash<QString, QString>();
   m_selectedViewOption = ectn_ALL_PKGS;
-  m_selectedRepository = "";
+  m_selectedRepository = QLatin1String("");
   m_numberOfInstalledPackages = 0;
   m_debugInfo = false;
   m_console = nullptr;
   m_optionsDialog = nullptr;
   m_commandExecuting=ectn_NONE;
   m_commandQueued=ectn_NONE;
-  m_sharedMemory = new QSharedMemory("org.arnt.octopi", this);
+  m_sharedMemory = new QSharedMemory(QStringLiteral("org.arnt.octopi"), this);
 
   m_tcpServer = new QTcpServer(this);
   connect(m_tcpServer, &QTcpServer::newConnection, this, &MainWindow::onSendInfoToOctopiHelper);
@@ -145,10 +145,10 @@ bool MainWindow::isNotifierBusy()
   bool res=false;
 
   //Checks first if octopi is running...
-  if (!UnixCommand::isOctoToolRunning("octopi-notifier")) return res;
+  if (!UnixCommand::isOctoToolRunning(QStringLiteral("octopi-notifier"))) return res;
 
   QTcpSocket socket;
-  socket.connectToHost("127.0.0.1", 12702);
+  socket.connectToHost(QStringLiteral("127.0.0.1"), 12702);
 
   if (!socket.waitForConnected(5000))
   {
@@ -170,7 +170,7 @@ bool MainWindow::isNotifierBusy()
     in >> octopiResponse;
   } while (!in.commitTransaction());
 
-  if (octopiResponse != "Octopi est occupatus")
+  if (octopiResponse != QLatin1String("Octopi est occupatus"))
   {
     res=false;
   }
@@ -192,7 +192,7 @@ bool MainWindow::startServer()
   if (!m_tcpServer->listen(QHostAddress::LocalHost, 12701))
   {
     QMessageBox::critical(this, StrConstants::getApplicationName(),
-                          QString("Unable to start the server: %1.")
+                          QStringLiteral("Unable to start the server: %1.")
                           .arg(m_tcpServer->errorString()));
     res=false;
   }
@@ -284,22 +284,22 @@ void MainWindow::onSendInfoToOctopiHelper()
 
   if (isHelperExecuting && m_commandExecuting != ectn_NONE)
   {
-    msg="Octopi est occupatus";
+    msg=QStringLiteral("Octopi est occupatus");
     out << msg;
   }
   else if (isHelperExecuting && m_commandExecuting == ectn_NONE)
   {
-    msg="Octopi serenum est";
+    msg=QStringLiteral("Octopi serenum est");
     out << msg;
   }
   else if (m_checkupdatesStringList->count() > 0 || m_outdatedStringList->count() > 0)
   {
-    msg="Renovatio potest";
+    msg=QStringLiteral("Renovatio potest");
     out << msg;
   }
   else
   {
-    msg="Atramento nigro";
+    msg=QStringLiteral("Atramento nigro");
     out << msg;
   }
 
@@ -327,7 +327,7 @@ void MainWindow::dropEvent(QDropEvent *ev)
   {
     QString str = url.fileName();
     QFileInfo f(str);
-    if (f.completeSuffix().contains("pkg.tar"))
+    if (f.completeSuffix().contains(QLatin1String("pkg.tar")))
     {
       m_packagesToInstallList.append(url.toLocalFile());
     }
@@ -349,7 +349,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *ev)
   {
     QString str = url.fileName();
     QFileInfo f(str);
-    if (f.completeSuffix().contains("pkg.tar"))
+    if (f.completeSuffix().contains(QLatin1String("pkg.tar")))
     {
       success=true;
       break;
@@ -437,7 +437,7 @@ QTextBrowser *MainWindow::getOutputTextBrowser()
 {
   QTextBrowser *ret=nullptr;
   QTextBrowser *text =
-      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
   if (text)
   {
@@ -452,13 +452,13 @@ QTextBrowser *MainWindow::getOutputTextBrowser()
  */
 void MainWindow::showAnchorDescription(const QUrl &link)
 {
-  if (link.toString().contains("goto:"))
+  if (link.toString().contains(QLatin1String("goto:")))
   {            
     QString pkgName = link.toString().mid(5);
     //Let's remove any "<" and "<=" symbol...
-    pkgName.remove(QRegularExpression("%3C\\S*"));
+    pkgName.remove(QRegularExpression(QStringLiteral("%3C\\S*")));
 
-    if (pkgName == "sh") pkgName = "bash";
+    if (pkgName == QLatin1String("sh")) pkgName = QStringLiteral("bash");
     QFuture<QString> f;
     disconnect(&g_fwToolTipInfo, SIGNAL(finished()), this, SLOT(execToolTip()));
     f = QtConcurrent::run(showPackageDescription, pkgName);
@@ -516,10 +516,10 @@ void MainWindow::positionInPackageList(const QString &pkgName)
  */
 void MainWindow::outputTextBrowserAnchorClicked(const QUrl &link)
 {
-  if (link.toString().contains("goto:"))
+  if (link.toString().contains(QLatin1String("goto:")))
   {
     QString pkgName = link.toString().mid(5);
-    if (pkgName == "sh") pkgName = "bash";
+    if (pkgName == QLatin1String("sh")) pkgName = QStringLiteral("bash");
     bool indIncremented = false;
     const QItemSelectionModel*const selectionModel = ui->tvPackages->selectionModel();
 
@@ -597,8 +597,8 @@ void MainWindow::outputOutdatedPackageList()
 
   if(m_numberOfOutdatedPackages > 0 && m_checkupdatesStringList->count() == 0)
   {
-    QString html = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
-    QString anchorBegin = "anchorBegin";
+    QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
+    QString anchorBegin = QStringLiteral("anchorBegin");
     html += "<a id=\"" + anchorBegin + "\"></a>";
 
     clearTabOutput();
@@ -612,7 +612,7 @@ void MainWindow::outputOutdatedPackageList()
           StrConstants::getOutdatedPackages(m_outdatedStringList->count()) + "</h3>";
     }
 
-    html += "<br><table border=\"0\">";
+    html += QLatin1String("<br><table border=\"0\">");
     html += "<tr><th width=\"25%\" align=\"left\">" + StrConstants::getName() +
         "</th><th width=\"18%\" align=\"right\">" +
         StrConstants::getOutdatedVersion() +
@@ -633,11 +633,11 @@ void MainWindow::outputOutdatedPackageList()
       }
     }
 
-    html += "</table><br>";
+    html += QLatin1String("</table><br>");
     writeToTabOutput(html);
 
     QTextBrowser *text =
-        ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+        ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
     if (text)
     {
@@ -647,8 +647,8 @@ void MainWindow::outputOutdatedPackageList()
     ui->twProperties->setCurrentIndex(ctn_TABINDEX_OUTPUT);
   }
   else {
-    QString html = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
-    QString anchorBegin = "anchorBegin";
+    QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
+    QString anchorBegin = QStringLiteral("anchorBegin");
     html += "<a id=\"" + anchorBegin + "\"></a>";
 
     clearTabOutput();
@@ -662,7 +662,7 @@ void MainWindow::outputOutdatedPackageList()
           StrConstants::getOutdatedPackages(m_outdatedStringList->count()) + "</h3>";
     }
 
-    html += "<br><table border=\"0\">";
+    html += QLatin1String("<br><table border=\"0\">");
     html += "<tr><th width=\"25%\" align=\"left\">" + StrConstants::getName() +
         "</th><th width=\"18%\" align=\"right\">" +
         StrConstants::getOutdatedVersion() +
@@ -683,11 +683,11 @@ void MainWindow::outputOutdatedPackageList()
       }
     }
 
-    html += "</table><br>";
+    html += QLatin1String("</table><br>");
     writeToTabOutput(html);
 
     QTextBrowser *text =
-        ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+        ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
     if (text)
     {
@@ -706,8 +706,8 @@ void MainWindow::outputAURVotedPackageList()
   if (m_aurVote!=nullptr)
   {
     clearTabOutput();
-    QString html = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
-    QString anchorBegin = "anchorBegin";
+    QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
+    QString anchorBegin = QStringLiteral("anchorBegin");
     html += "<a id=\"" + anchorBegin + "\"></a>";
     html += "<h3>" + StrConstants::getAURVotedPackageList() + "</h3>";
     writeToTabOutput(html);
@@ -715,18 +715,18 @@ void MainWindow::outputAURVotedPackageList()
 
     QStringList v=m_aurVote->getVotedPackages();
     v.sort();
-    QString list="<ul>";
+    QString list=QStringLiteral("<ul>");
     foreach(QString vote, v)
     {
       list += "<li>" + vote + "</li>";
     }
 
-    list += "</ul><br>";
+    list += QLatin1String("</ul><br>");
 
     writeToTabOutput(list);
 
     QTextBrowser *text =
-        ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+        ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
     if (text)
     {
@@ -743,8 +743,8 @@ void MainWindow::outputOutdatedAURPackageList()
   //We cannot output any list if there is a running transaction!
   if (m_commandExecuting != ectn_NONE) return;
 
-  QString html = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
-  QString anchorBegin = "anchorBegin";
+  QString html = QStringLiteral("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
+  QString anchorBegin = QStringLiteral("anchorBegin");
   html += "<a id=\"" + anchorBegin + "\"></a>";
 
   clearTabOutput();
@@ -758,7 +758,7 @@ void MainWindow::outputOutdatedAURPackageList()
         StrConstants::getOutdatedPackages(m_outdatedAURStringList->count()) + "</h3>";
   }
 
-  html += "<br><table border=\"0\">";
+  html += QLatin1String("<br><table border=\"0\">");
   html += "<tr><th width=\"25%\" align=\"left\">" + StrConstants::getName() +
       "</th><th width=\"18%\" align=\"right\">" +
       StrConstants::getOutdatedVersion() +
@@ -780,11 +780,11 @@ void MainWindow::outputOutdatedAURPackageList()
     }
   }
 
-  html += "</table><br>";
+  html += QLatin1String("</table><br>");
   writeToTabOutput(html);
 
   QTextBrowser *text =
-      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
   if (text)
   {
@@ -799,7 +799,7 @@ void MainWindow::outputOutdatedAURPackageList()
  */
 void MainWindow::clearTabOutput()
 {
-  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (text)
   {
     text->clear();
@@ -905,8 +905,8 @@ void MainWindow::setCallSystemUpgradeNoConfirm()
 void MainWindow::setRemoveCommand(const QString &removeCommand)
 {
   m_removeCommand = removeCommand;
-  m_removeCommand.remove("=");
-  m_removeCommand.remove("-");
+  m_removeCommand.remove(QStringLiteral("="));
+  m_removeCommand.remove(QStringLiteral("-"));
 }
 
 /*
@@ -1000,11 +1000,11 @@ void MainWindow::tvPackagesSearchColumnChanged(QAction *actionSelected)
 void MainWindow::changePackageListModel(ViewOptions viewOptions, QString selectedRepo)
 {  
   if (m_actionSwitchToAURTool->isChecked())
-    m_packageModel->applyFilter(viewOptions, "", StrConstants::getForeignToolGroup());
+    m_packageModel->applyFilter(viewOptions, QLatin1String(""), StrConstants::getForeignToolGroup());
   else
-    m_packageModel->applyFilter(viewOptions, selectedRepo, isAllGroupsSelected() ? "" : getSelectedGroup());
+    m_packageModel->applyFilter(viewOptions, selectedRepo, isAllGroupsSelected() ? QLatin1String("") : getSelectedGroup());
 
-  if (m_leFilterPackage->text() != "") reapplyPackageFilter();
+  if (m_leFilterPackage->text() != QLatin1String("")) reapplyPackageFilter();
 
   QModelIndex cIcon = m_packageModel->index(0, PackageModel::ctn_PACKAGE_ICON_COLUMN, QModelIndex());
 
@@ -1273,7 +1273,7 @@ void MainWindow::onAURUnvote()
  * This SLOT collapses all treeview items
  */
 void MainWindow::collapseAllContentItems(){
-  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
   if (tv != nullptr)
     tv->collapseAll();
 }
@@ -1282,7 +1282,7 @@ void MainWindow::collapseAllContentItems(){
  * This SLOT collapses only the currently selected item
  */
 void MainWindow::collapseThisContentItems(){
-  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
   if (tv != nullptr)
   {
     tv->repaint(tv->rect());
@@ -1301,7 +1301,7 @@ void MainWindow::collapseThisContentItems(){
  * This SLOT expands all treeview items
  */
 void MainWindow::expandAllContentItems(){
-  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
   if (tv != nullptr)
   {
     tv->repaint(tv->rect());
@@ -1314,7 +1314,7 @@ void MainWindow::expandAllContentItems(){
  * This SLOT expands only the currently selected item
  */
 void MainWindow::expandThisContentItems(){
-  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
   if (tv != nullptr)
   {
     tv->repaint(tv->rect());
@@ -1365,7 +1365,7 @@ void MainWindow::expandItem(QTreeView* tv, QStandardItemModel* sim, QModelIndex*
 void MainWindow::execContextMenuPkgFileList(QPoint point)
 {
   QTreeView *tvPkgFileList =
-      ui->twProperties->currentWidget()->findChild<QTreeView*>("tvPkgFileList");
+      ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
 
   if (tvPkgFileList == nullptr)
   {
@@ -1430,7 +1430,7 @@ void MainWindow::execContextMenuPkgFileList(QPoint point)
  */
 void MainWindow::execContextMenuTransaction(QPoint point)
 {
-  QTreeView *tvTransaction = ui->twProperties->currentWidget()->findChild<QTreeView*>("tvTransaction");
+  QTreeView *tvTransaction = ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
   if (!tvTransaction) return;
 
   if ((tvTransaction->currentIndex() == getRemoveTransactionParentItem()->index() &&
@@ -1493,7 +1493,7 @@ bool MainWindow::isPackageTreeViewVisible()
  */
 void MainWindow::selectFirstItemOfPkgFileList()
 {
-  QTreeView *tvPkgFileList = ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+  QTreeView *tvPkgFileList = ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
   if(tvPkgFileList)
   {
     tvPkgFileList->setFocus();
@@ -1507,7 +1507,7 @@ void MainWindow::selectFirstItemOfPkgFileList()
  */
 void MainWindow::closeTabFilesSearchBar()
 {
-  SearchBar *searchBar = ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<SearchBar*>("searchbar");
+  SearchBar *searchBar = ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<SearchBar*>(QStringLiteral("searchbar"));
   if (searchBar)
   {
     if (ui->twProperties->currentIndex() == ctn_TABINDEX_FILES)
@@ -1728,7 +1728,7 @@ void MainWindow::maxDemaxPropertiesTabWidget(bool pSaveSettings)
 
     if (ui->twProperties->currentIndex() == ctn_TABINDEX_FILES)
     {
-      QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList");
+      QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList"));
       if (tv)
         tv->scrollTo(tv->currentIndex());
     }
@@ -1774,7 +1774,7 @@ void MainWindow::headerViewPackageListSortIndicatorClicked( int col, Qt::SortOrd
 void MainWindow::positionTextEditCursorAtEnd()
 {
   QTextBrowser *textEdit =
-      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (textEdit)
   {
     utils::positionTextEditCursorAtEnd(textEdit);
@@ -1807,7 +1807,7 @@ bool MainWindow::textInTabOutput(const QString& findText)
 {
   bool res = false;
   QTextBrowser *text =
-      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (text)
   {
     res = utils::strInQTextEdit(text,findText);
@@ -1823,7 +1823,7 @@ bool MainWindow::IsSyncingRepoInTabOutput()
 {
   bool res = false;
   QTextBrowser *text =
-      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+      ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (text)
   {
     positionTextEditCursorAtEnd();
@@ -1835,7 +1835,7 @@ bool MainWindow::IsSyncingRepoInTabOutput()
     if (!res)
     {
       positionTextEditCursorAtEnd();
-      res = text->find("downloading", QTextDocument::FindBackward | QTextDocument::FindWholeWords);
+      res = text->find(QStringLiteral("downloading"), QTextDocument::FindBackward | QTextDocument::FindWholeWords);
     }
 
     positionTextEditCursorAtEnd();
@@ -1849,7 +1849,7 @@ bool MainWindow::IsSyncingRepoInTabOutput()
  */
 void MainWindow::openFile()
 {
-  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
   if (tv)
   {
     QString path = utils::showFullPathOfItem(tv->currentIndex());
@@ -1867,7 +1867,7 @@ void MainWindow::openFile()
  */
 void MainWindow::editFile()
 {
-  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+  QTreeView *tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
   if (tv)
   {
     QString path = utils::showFullPathOfItem(tv->currentIndex());
@@ -1933,8 +1933,8 @@ void MainWindow::findFileInPackage()
 {
   refreshTabFiles(false, true);
 
-  QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>("tvPkgFileList");
-  SearchBar *searchBar = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+  QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
+  SearchBar *searchBar = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
   if (tb && tb->model()->rowCount() > 0 && searchBar)
   {
@@ -1955,7 +1955,7 @@ QString MainWindow::getSelectedDirectory()
   QString targetDir;
   if (isPropertiesTabWidgetVisible() && ui->twProperties->currentIndex() == ctn_TABINDEX_FILES)
   {
-    QTreeView *t = ui->twProperties->currentWidget()->findChild<QTreeView*>("tvPkgFileList");
+    QTreeView *t = ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
     if(t && t->currentIndex().isValid())
     {
       QString itemPath = utils::showFullPathOfItem(t->currentIndex());
@@ -2012,7 +2012,7 @@ void MainWindow::tvPackagesSelectionChanged(const QItemSelection&, const QItemSe
 void MainWindow::launchPLV()
 {
   QProcess *proc = new QProcess();
-  proc->startDetached("plv");
+  proc->startDetached(QStringLiteral("plv"));
 }
 
 /*
@@ -2021,7 +2021,7 @@ void MainWindow::launchPLV()
 void MainWindow::launchRepoEditor()
 {
   m_unixCommand = new UnixCommand(this);
-  m_unixCommand->execCommandAsNormalUser(QLatin1String("octopi-repoeditor"));
+  m_unixCommand->execCommandAsNormalUser(QStringLiteral("octopi-repoeditor"));
 }
 
 /*
@@ -2030,7 +2030,7 @@ void MainWindow::launchRepoEditor()
 void MainWindow::launchCacheCleaner()
 {
   m_unixCommand = new UnixCommand(this);
-  m_unixCommand->execCommandAsNormalUser(QLatin1String("octopi-cachecleaner"));
+  m_unixCommand->execCommandAsNormalUser(QStringLiteral("octopi-cachecleaner"));
 }
 
 /*
@@ -2038,7 +2038,7 @@ void MainWindow::launchCacheCleaner()
  */
 void MainWindow::doSysInfo()
 {
-  if (!UnixCommand::hasTheExecutable("curl") ||
+  if (!UnixCommand::hasTheExecutable(QStringLiteral("curl")) ||
       m_commandExecuting != ectn_NONE) return;
 
   if (!isInternetAvailable()) return;
@@ -2053,19 +2053,19 @@ void MainWindow::doSysInfo()
   disableTransactionActions();
   m_commandExecuting = ectn_SYSINFO;
   clearTabOutput();
-  writeToTabOutput("<b>SysInfo...</b><br>");
+  writeToTabOutput(QStringLiteral("<b>SysInfo...</b><br>"));
 
   QString command;
   QEventLoop el;
   QFuture<QByteArray> f;
-  command="hostname";
+  command=QStringLiteral("hostname");
   f = QtConcurrent::run(execCommand, command);
   connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
   g_fwCommandToExecute.setFuture(f);
   el.exec();
   QString hostname = g_fwCommandToExecute.result();
 
-  hostname.remove("\n");
+  hostname.remove(QStringLiteral("\n"));
   QString homePath = QDir::homePath();
   QByteArray out;
 
@@ -2075,7 +2075,7 @@ void MainWindow::doSysInfo()
     out += "cat /etc/KaOS-release\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "cat /etc/KaOS-release";
+    command = QStringLiteral("cat /etc/KaOS-release");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2092,7 +2092,7 @@ void MainWindow::doSysInfo()
     out += "cat /etc/lsb-release\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "cat /etc/lsb-release";
+    command = QStringLiteral("cat /etc/lsb-release");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2104,13 +2104,13 @@ void MainWindow::doSysInfo()
     out += "\n\n";
   }
 
-  if (UnixCommand::hasTheExecutable("inxi"))
+  if (UnixCommand::hasTheExecutable(QStringLiteral("inxi")))
   {
     out += "----------------------------------------------------------------------------------------------------------\n";
     out += "inxi -Fxz\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "inxi -Fxz -c 0";
+    command = QStringLiteral("inxi -Fxz -c 0");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2127,7 +2127,7 @@ void MainWindow::doSysInfo()
     out += "uname -a\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "uname -a";
+    command = QStringLiteral("uname -a");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2139,13 +2139,13 @@ void MainWindow::doSysInfo()
     out += "\n\n";
   }
 
-  if (UnixCommand::hasTheExecutable("mhwd"))
+  if (UnixCommand::hasTheExecutable(QStringLiteral("mhwd")))
   {
     out += "----------------------------------------------------------------------------------------------------------\n";
     out += "mhwd -li -d\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "mhwd -li -d";
+    command = QStringLiteral("mhwd -li -d");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2161,7 +2161,7 @@ void MainWindow::doSysInfo()
   out += "journalctl -b -p err\n";
   out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-  command = "journalctl -b -p err";
+  command = QStringLiteral("journalctl -b -p err");
   f = QtConcurrent::run(execCommand, command);
   connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
   g_fwCommandToExecute.setFuture(f);
@@ -2176,7 +2176,7 @@ void MainWindow::doSysInfo()
   out += "cat /etc/pacman.conf\n";
   out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-  command = "cat /etc/pacman.conf";
+  command = QStringLiteral("cat /etc/pacman.conf");
   f = QtConcurrent::run(execCommand, command);
   connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
   g_fwCommandToExecute.setFuture(f);
@@ -2191,7 +2191,7 @@ void MainWindow::doSysInfo()
   out += "pacman -Qm\n";
   out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-  command = "pacman -Qm";
+  command = QStringLiteral("pacman -Qm");
   f = QtConcurrent::run(execCommand, command);
   connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
   g_fwCommandToExecute.setFuture(f);
@@ -2208,7 +2208,7 @@ void MainWindow::doSysInfo()
     out += "cat /var/log/pacman.log\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "cat /var/log/pacman.log";
+    command = QStringLiteral("cat /var/log/pacman.log");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2223,7 +2223,7 @@ void MainWindow::doSysInfo()
     out += "cat /var/log/installation.log\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "cat /var/log/installation.log";
+    command = QStringLiteral("cat /var/log/installation.log");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);
@@ -2241,7 +2241,7 @@ void MainWindow::doSysInfo()
     out += "head --bytes=256K /var/log/pacman.log\n";
     out += "----------------------------------------------------------------------------------------------------------\n\n";
 
-    command = "head --bytes=256K /var/log/pacman.log";
+    command = QStringLiteral("head --bytes=256K /var/log/pacman.log");
     f = QtConcurrent::run(execCommand, command);
     connect(&g_fwCommandToExecute, SIGNAL(finished()), &el, SLOT(quit()));
     g_fwCommandToExecute.setFuture(f);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -520,7 +520,7 @@ public:
     if (w != nullptr) return w;
     foreach (QWidget *widget, QApplication::topLevelWidgets())
     {
-      if (widget->objectName() == "MainWindow")
+      if (widget->objectName() == QLatin1String("MainWindow"))
         w = dynamic_cast<MainWindow*>(widget);
     }
     return w;

--- a/src/mainwindow_events.cpp
+++ b/src/mainwindow_events.cpp
@@ -54,7 +54,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
   if(m_commandExecuting != ectn_NONE)
   {
     int res = QMessageBox::question(this, StrConstants::getConfirmation(),
-                          StrConstants::getThereIsARunningTransaction() + "\n" +
+                          StrConstants::getThereIsARunningTransaction() + QLatin1Char('\n') +
                           StrConstants::getDoYouReallyWantToQuit(),
                           QMessageBox::Yes | QMessageBox::No,
                           QMessageBox::No);
@@ -71,7 +71,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
   else if(areTherePendingActions())
   {
     int res = QMessageBox::question(this, StrConstants::getConfirmation(),
-                                    StrConstants::getThereArePendingActions() + "\n" +
+                                    StrConstants::getThereArePendingActions() + QLatin1Char('\n') +
                                     StrConstants::getDoYouReallyWantToQuit(),
                                     QMessageBox::Yes | QMessageBox::No,
                                     QMessageBox::No);

--- a/src/mainwindow_events.cpp
+++ b/src/mainwindow_events.cpp
@@ -104,7 +104,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
  */
 void MainWindow::copyFullPathToClipboard()
 {
-  QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>("tvPkgFileList");
+  QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
   if (tb && tb->hasFocus())
   {
     QString path = utils::showFullPathOfItem(tb->currentIndex());
@@ -118,7 +118,7 @@ void MainWindow::copyFullPathToClipboard()
  */
 void testSharedMem()
 {
-  QSharedMemory *sharedMem=new QSharedMemory("org.arnt.test");
+  QSharedMemory *sharedMem=new QSharedMemory(QStringLiteral("org.arnt.test"));
   QByteArray sharedData="abracadabra -abcd\ncadabraabra -xyz";
 
   //removeSharedMemFiles();
@@ -129,7 +129,7 @@ void testSharedMem()
   sharedMem->unlock();
 
   //Let's retrieve commands from sharedmem pool
-  QSharedMemory *sharedMem2 = new QSharedMemory("org.arnt.test");
+  QSharedMemory *sharedMem2 = new QSharedMemory(QStringLiteral("org.arnt.test"));
   if (!sharedMem2->attach(QSharedMemory::ReadOnly))
   {
     QTextStream qout(stdout);
@@ -202,7 +202,7 @@ void MainWindow::keyPressEvent(QKeyEvent* ke)
     else
     {
       QTreeView *tvPkgFileList =
-          ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+          ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
 
       if(tvPkgFileList)
       {
@@ -308,8 +308,8 @@ void MainWindow::keyPressEvent(QKeyEvent* ke)
          ui->twProperties->currentIndex() == ctn_TABINDEX_NEWS ||
          ui->twProperties->currentIndex() == ctn_TABINDEX_HELPUSAGE))
     {
-      QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>("textBrowser");
-      SearchBar *searchBar = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+      QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
+      SearchBar *searchBar = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
       if (tb && tb->toPlainText().size() > 0 && searchBar)
       {
@@ -318,8 +318,8 @@ void MainWindow::keyPressEvent(QKeyEvent* ke)
     }
     else if (isPropertiesTabWidgetVisible() && ui->twProperties->currentIndex() == ctn_TABINDEX_FILES)
     {
-      QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>("tvPkgFileList");
-      SearchBar *searchBar = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+      QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
+      SearchBar *searchBar = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
       if (tb && tb->model()->rowCount() > 0 && searchBar)
       {

--- a/src/mainwindow_help.cpp
+++ b/src/mainwindow_help.cpp
@@ -44,7 +44,7 @@ void MainWindow::initTabHelpUsage()
   gridLayoutX->setMargin(0);
 
   QTextBrowser *text = new QTextBrowser(tabHelpUsage);
-  text->setObjectName("textBrowser");
+  text->setObjectName(QStringLiteral("textBrowser"));
   text->setReadOnly(true);
   text->setFrameShape(QFrame::NoFrame);
   text->setFrameShadow(QFrame::Plain);
@@ -84,7 +84,7 @@ QString MainWindow::generateHelpUsageHtmlText()
     strOutdatedAur="<li>" +
         tr("Ctrl+Shift+O to display outdated %1 packages").arg(StrConstants::getForeignRepositoryName()) + "</li>";
   }
-  else strOutdatedAur="<li></li>";
+  else strOutdatedAur=QStringLiteral("<li></li>");
 
   QString strVote;
   if(m_aurVote != nullptr)
@@ -92,113 +92,113 @@ QString MainWindow::generateHelpUsageHtmlText()
     strVote="<li>" +
        tr("Ctrl+Shift+A to display AUR voted package list") + "</li>";
   }
-  else strVote="<li></li>";
+  else strVote=QStringLiteral("<li></li>");
 
-  QString iconPath = "<img height=\"16\" width=\"16\" src=\":/resources/images/";
+  QString iconPath = QStringLiteral("<img height=\"16\" width=\"16\" src=\":/resources/images/");
   QString strForMoreInfo = tr("For more information, visit:");
   QString html =
-    QString("<h2>Octopi</h2>") +
-    QString("<h3><p>") + tr("A Qt-based Pacman frontend,") + " " +
+    QStringLiteral("<h2>Octopi</h2>") +
+    QStringLiteral("<h3><p>") + tr("A Qt-based Pacman frontend,") + " " +
     tr("licensed under the terms of") + " ";
 
     html +=
-      QString("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a>.</p></h3>") +
-      QString("<h4><p>") + strForMoreInfo + " " +
-      QString("<a href=\"http://octopiproject.wordpress.com\">http://octopiproject.wordpress.com</a>.</p></h4><br>");
+      QStringLiteral("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a>.</p></h3>") +
+      QStringLiteral("<h4><p>") + strForMoreInfo + " " +
+      QStringLiteral("<a href=\"http://octopiproject.wordpress.com\">http://octopiproject.wordpress.com</a>.</p></h4><br>");
     html +=
       tr("Package classification:") +
 
-  QString("<ul type=\"square\"><li>") + iconPath + "installed.png\"/> " +
-     tr("An installed package") + QString("</li>") +
-  QString("<li>") + iconPath + "unrequired.png\"/> " +
+  QStringLiteral("<ul type=\"square\"><li>") + iconPath + "installed.png\"/> " +
+     tr("An installed package") + QStringLiteral("</li>") +
+  QStringLiteral("<li>") + iconPath + "unrequired.png\"/> " +
      tr("An installed package (not required by others)") +
-  QString("</li>") +
+  QStringLiteral("</li>") +
   QString("<li>" + iconPath + "foreign_green.png\"/> ") +
      tr("A foreign package, installed from") + " " + StrConstants::getForeignRepositoryName() +
-  QString("</li>") +
-  QString("<li>") + iconPath + "noninstalled.png\"/> " +
+  QStringLiteral("</li>") +
+  QStringLiteral("<li>") + iconPath + "noninstalled.png\"/> " +
      tr("A non installed package") +
-  QString("</li>") +
-  QString("<li>") + iconPath + "outdated.png\"/> " +
+  QStringLiteral("</li>") +
+  QStringLiteral("<li>") + iconPath + "outdated.png\"/> " +
      tr("An outdated package") +
-  QString("</li>") +
-  QString("<li>") + iconPath + "foreign_red.png\"/> " +
+  QStringLiteral("</li>") +
+  QStringLiteral("<li>") + iconPath + "foreign_red.png\"/> " +
      tr("An outdated foreign package") +
-  QString("</li>") +
-  QString("<li>") + iconPath + "newer.png\"/> " +
+  QStringLiteral("</li>") +
+  QStringLiteral("<li>") + iconPath + "newer.png\"/> " +
            tr("A newer than repository package") +
-  QString("</li></ul>") +
+  QStringLiteral("</li></ul>") +
      tr("Basic usage help:") +
-  QString("<ul><li>") +
+  QStringLiteral("<ul><li>") +
      tr("Position the mouse over a package to see its description") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Double click an installed package to see its contents") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Right click package to install/reinstall or remove it") +
-  QString("</li></ul>") +
+  QStringLiteral("</li></ul>") +
 
      tr("Alt+key sequences:") +
-  QString("<ul><li>") +
+  QStringLiteral("<ul><li>") +
      tr("Alt+1 to switch to 'Info' tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Alt+2 to switch to 'Files' tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Alt+3 to switch to 'Actions' tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Alt+4 to switch to 'Output' tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Alt+5 to switch to 'News' tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Alt+6 or 'F1' to show this help page") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Alt+7 to switch to 'Terminal' tab") +
-  QString("</li></ul>") +
+  QStringLiteral("</li></ul>") +
 
      tr("Control+key sequences:") +
-  QString("<ul><li>") +
+  QStringLiteral("<ul><li>") +
      tr("Ctrl+E or 'Actions/Cancel' to clear the selection of to be removed/installed packages") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+F to search for text inside tab Files, News and Usage") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+G or 'File/Get latest distro news' to retrieve the latest RSS based distro news") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+K or 'File/Check updates' to check mirror for latest updates (checkupdates)") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+L to find a package in the package list") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+P to go to package list") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+Q or 'File/Exit' to exit the application") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+U or 'File/System upgrade' to make a full system upgrade (pacman -Su)") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("Ctrl+Y or 'Actions/Apply' to start installation/removal of selected packages") +
-  QString("</li></ul>") +
+  QStringLiteral("</li></ul>") +
 
      tr("Control+shift+key sequences:") +
-  QString("<ul>") +
+  QStringLiteral("<ul>") +
   strVote +
-  QString("<li>") +
+  QStringLiteral("<li>") +
      tr("Ctrl+Shift+G to display all package groups") +
-  QString("</li>") +
+  QStringLiteral("</li>") +
      strOutdatedAur + "<li>" +
      //tr("Ctrl+Shift+R to remove Pacman's transaction lock file") +
   //QString("</li><li>") +
      tr("Ctrl+Shift+Y to display %1 group").arg(StrConstants::getForeignRepositoryGroupName()) +
-  QString("</li></ul>") +
+  QStringLiteral("</li></ul>") +
 
      tr("F+key sequences:") +
-  QString("<ul><li>") +
+  QStringLiteral("<ul><li>") +
      tr("F1 to show this help page") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("F4 to open a Terminal whitin the selected directory at Files tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("F6 to open a File Manager whitin the selected directory at Files tab") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("F10 to maximize/demaximize package list view") +
-  QString("</li><li>") +
+  QStringLiteral("</li><li>") +
      tr("F11 to maximize/demaximize Tab's view") +
-  QString("</li></ul><br>");
+  QStringLiteral("</li></ul><br>");
 
   //html += "<br>" + strNoPassword;
 
@@ -211,7 +211,7 @@ QString MainWindow::generateHelpUsageHtmlText()
 void MainWindow::refreshHelpUsageText()
 {
   QTextBrowser *text =
-      ui->twProperties->widget(ctn_TABINDEX_HELPUSAGE)->findChild<QTextBrowser*>("textBrowser");
+      ui->twProperties->widget(ctn_TABINDEX_HELPUSAGE)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (!text) return;
 
   text->setText(generateHelpUsageHtmlText());
@@ -230,7 +230,7 @@ void MainWindow::onHelpUsage()
  */
 void MainWindow::onHelpDonate()
 {
-  const QString url="http://sourceforge.net/donate/index.php?group_id=186459";
+  const QString url=QStringLiteral("http://sourceforge.net/donate/index.php?group_id=186459");
   QDesktopServices::openUrl(QUrl(url));
 }
 
@@ -245,18 +245,18 @@ void MainWindow::onHelpAbout()
   aboutText += StrConstants::getVersion() + ": " + StrConstants::getApplicationVersion() + " - " + StrConstants::getQtVersion() + "<br>";
   aboutText += StrConstants::getURL() + ": " +
       "<a href=\"https://tintaescura.com/projects/octopi/\">https://tintaescura.com/projects/octopi</a><br>";
-  aboutText += StrConstants::getLicenses() + ": " + QString("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a><br>");
-  aboutText += "&copy; Alexandre Albuquerque Arnt<br><br>";
+  aboutText += StrConstants::getLicenses() + ": " + QStringLiteral("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a><br>");
+  aboutText += QLatin1String("&copy; Alexandre Albuquerque Arnt<br><br>");
 
-  aboutText += "<b>Pacman</b><br>";
+  aboutText += QLatin1String("<b>Pacman</b><br>");
   QString pacmanV = UnixCommand::getPacmanVersion();
   if (pacmanV.at(0) == 'v') pacmanV.remove(0, 1);
   aboutText += StrConstants::getVersion() + ": " + pacmanV + "<br>";
   aboutText += StrConstants::getURL() + ": " +
       "<a href=\"https://www.archlinux.org/pacman/\">https://www.archlinux.org/pacman</a><br>";
   QDate d = QDate::currentDate();
-  aboutText += "&copy; 2006-%1 Pacman Development Team<br>";
-  aboutText += "&copy; 2002-2006 Judd Vinet";
+  aboutText += QLatin1String("&copy; 2006-%1 Pacman Development Team<br>");
+  aboutText += QLatin1String("&copy; 2002-2006 Judd Vinet");
   aboutText = aboutText.arg(d.year());
 
   QMessageBox::about(this, StrConstants::getHelpAbout(), aboutText);

--- a/src/mainwindow_help.cpp
+++ b/src/mainwindow_help.cpp
@@ -81,16 +81,16 @@ QString MainWindow::generateHelpUsageHtmlText()
   QString strOutdatedAur;
   if(m_hasAURTool && UnixCommand::getLinuxDistro() != ectn_CHAKRA && !SettingsManager::getSearchOutdatedAURPackages())
   {
-    strOutdatedAur="<li>" +
-        tr("Ctrl+Shift+O to display outdated %1 packages").arg(StrConstants::getForeignRepositoryName()) + "</li>";
+    strOutdatedAur=QLatin1String("<li>") +
+        tr("Ctrl+Shift+O to display outdated %1 packages").arg(StrConstants::getForeignRepositoryName()) + QLatin1String("</li>");
   }
   else strOutdatedAur=QStringLiteral("<li></li>");
 
   QString strVote;
   if(m_aurVote != nullptr)
   {
-    strVote="<li>" +
-       tr("Ctrl+Shift+A to display AUR voted package list") + "</li>";
+    strVote=QLatin1String("<li>") +
+       tr("Ctrl+Shift+A to display AUR voted package list") + QLatin1String("</li>");
   }
   else strVote=QStringLiteral("<li></li>");
 
@@ -98,34 +98,34 @@ QString MainWindow::generateHelpUsageHtmlText()
   QString strForMoreInfo = tr("For more information, visit:");
   QString html =
     QStringLiteral("<h2>Octopi</h2>") +
-    QStringLiteral("<h3><p>") + tr("A Qt-based Pacman frontend,") + " " +
-    tr("licensed under the terms of") + " ";
+    QStringLiteral("<h3><p>") + tr("A Qt-based Pacman frontend,") + QLatin1Char(' ') +
+    tr("licensed under the terms of") + QLatin1Char(' ');
 
     html +=
       QStringLiteral("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a>.</p></h3>") +
-      QStringLiteral("<h4><p>") + strForMoreInfo + " " +
+      QStringLiteral("<h4><p>") + strForMoreInfo + QLatin1Char(' ') +
       QStringLiteral("<a href=\"http://octopiproject.wordpress.com\">http://octopiproject.wordpress.com</a>.</p></h4><br>");
     html +=
       tr("Package classification:") +
 
-  QStringLiteral("<ul type=\"square\"><li>") + iconPath + "installed.png\"/> " +
+  QStringLiteral("<ul type=\"square\"><li>") + iconPath + QLatin1String("installed.png\"/> ") +
      tr("An installed package") + QStringLiteral("</li>") +
-  QStringLiteral("<li>") + iconPath + "unrequired.png\"/> " +
+  QStringLiteral("<li>") + iconPath + QLatin1String("unrequired.png\"/> ") +
      tr("An installed package (not required by others)") +
   QStringLiteral("</li>") +
-  QString("<li>" + iconPath + "foreign_green.png\"/> ") +
-     tr("A foreign package, installed from") + " " + StrConstants::getForeignRepositoryName() +
+  QString(QLatin1String("<li>") + iconPath + QLatin1String("foreign_green.png\"/> ")) +
+     tr("A foreign package, installed from") + QLatin1Char(' ') + StrConstants::getForeignRepositoryName() +
   QStringLiteral("</li>") +
-  QStringLiteral("<li>") + iconPath + "noninstalled.png\"/> " +
+  QStringLiteral("<li>") + iconPath + QLatin1String("noninstalled.png\"/> ") +
      tr("A non installed package") +
   QStringLiteral("</li>") +
-  QStringLiteral("<li>") + iconPath + "outdated.png\"/> " +
+  QStringLiteral("<li>") + iconPath + QLatin1String("outdated.png\"/> ") +
      tr("An outdated package") +
   QStringLiteral("</li>") +
-  QStringLiteral("<li>") + iconPath + "foreign_red.png\"/> " +
+  QStringLiteral("<li>") + iconPath + QLatin1String("foreign_red.png\"/> ") +
      tr("An outdated foreign package") +
   QStringLiteral("</li>") +
-  QStringLiteral("<li>") + iconPath + "newer.png\"/> " +
+  QStringLiteral("<li>") + iconPath + QLatin1String("newer.png\"/> ") +
            tr("A newer than repository package") +
   QStringLiteral("</li></ul>") +
      tr("Basic usage help:") +
@@ -181,7 +181,7 @@ QString MainWindow::generateHelpUsageHtmlText()
   QStringLiteral("<li>") +
      tr("Ctrl+Shift+G to display all package groups") +
   QStringLiteral("</li>") +
-     strOutdatedAur + "<li>" +
+     strOutdatedAur + QLatin1String("<li>") +
      //tr("Ctrl+Shift+R to remove Pacman's transaction lock file") +
   //QString("</li><li>") +
      tr("Ctrl+Shift+Y to display %1 group").arg(StrConstants::getForeignRepositoryGroupName()) +
@@ -240,20 +240,20 @@ void MainWindow::onHelpDonate()
 void MainWindow::onHelpAbout()
 {
   QString aboutText =
-      "<b>" + StrConstants::getApplicationName() + "</b><br>";
+      QLatin1String("<b>") + StrConstants::getApplicationName() + QLatin1String("</b><br>");
 
-  aboutText += StrConstants::getVersion() + ": " + StrConstants::getApplicationVersion() + " - " + StrConstants::getQtVersion() + "<br>";
-  aboutText += StrConstants::getURL() + ": " +
-      "<a href=\"https://tintaescura.com/projects/octopi/\">https://tintaescura.com/projects/octopi</a><br>";
-  aboutText += StrConstants::getLicenses() + ": " + QStringLiteral("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a><br>");
+  aboutText += StrConstants::getVersion() + QLatin1String(": ") + StrConstants::getApplicationVersion() + QLatin1String(" - ") + StrConstants::getQtVersion() + QLatin1String("<br>");
+  aboutText += StrConstants::getURL() + QLatin1String(": ") +
+      QStringLiteral("<a href=\"https://tintaescura.com/projects/octopi/\">https://tintaescura.com/projects/octopi</a><br>");
+  aboutText += StrConstants::getLicenses() + QLatin1String(": ") + QStringLiteral("<a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GPL v2</a><br>");
   aboutText += QLatin1String("&copy; Alexandre Albuquerque Arnt<br><br>");
 
   aboutText += QLatin1String("<b>Pacman</b><br>");
   QString pacmanV = UnixCommand::getPacmanVersion();
-  if (pacmanV.at(0) == 'v') pacmanV.remove(0, 1);
-  aboutText += StrConstants::getVersion() + ": " + pacmanV + "<br>";
-  aboutText += StrConstants::getURL() + ": " +
-      "<a href=\"https://www.archlinux.org/pacman/\">https://www.archlinux.org/pacman</a><br>";
+  if (pacmanV.at(0) == QLatin1Char('v')) pacmanV.remove(0, 1);
+  aboutText += StrConstants::getVersion() + QLatin1String(": ") + pacmanV + QLatin1String("<br>");
+  aboutText += StrConstants::getURL() + QLatin1String(": ") +
+      QLatin1String("<a href=\"https://www.archlinux.org/pacman/\">https://www.archlinux.org/pacman</a><br>");
   QDate d = QDate::currentDate();
   aboutText += QLatin1String("&copy; 2006-%1 Pacman Development Team<br>");
   aboutText += QLatin1String("&copy; 2002-2006 Judd Vinet");

--- a/src/mainwindow_init.cpp
+++ b/src/mainwindow_init.cpp
@@ -452,7 +452,7 @@ void MainWindow::initTabTransaction()
   gridLayoutX->setMargin(0);
 
   QTreeView *tvTransaction = new QTreeView(tabTransaction);
-  tvTransaction->setObjectName("tvTransaction");
+  tvTransaction->setObjectName(QStringLiteral("tvTransaction"));
   tvTransaction->setContextMenuPolicy(Qt::CustomContextMenu);
   tvTransaction->setEditTriggers(QAbstractItemView::NoEditTriggers);
   tvTransaction->setDropIndicatorShown(false);
@@ -561,7 +561,7 @@ void MainWindow::initTabInfo(){
   gridLayoutX->setMargin ( 0 );
 
   QTextBrowser *text = new QTextBrowser(tabInfo);
-  text->setObjectName("textBrowser");
+  text->setObjectName(QStringLiteral("textBrowser"));
   text->setReadOnly(true);
   text->setFrameShape(QFrame::NoFrame);
   text->setFrameShadow(QFrame::Plain);
@@ -646,7 +646,7 @@ void MainWindow::onExecCommandInTabTerminal(QString command)
   connect(m_console, SIGNAL(onCancelControlKey()), this, SLOT(onCancelControlKey()));
 
   m_console->enter();
-  m_console->execute("clear");
+  m_console->execute(QStringLiteral("clear"));
   m_console->execute(command);
   m_console->setFocus();
 }
@@ -671,7 +671,7 @@ void MainWindow::initTabFiles()
   tvPkgFileList->header()->setSectionResizeMode(QHeaderView::Fixed);
   tvPkgFileList->setFrameShape(QFrame::NoFrame);
   tvPkgFileList->setFrameShadow(QFrame::Plain);
-  tvPkgFileList->setObjectName("tvPkgFileList");
+  tvPkgFileList->setObjectName(QStringLiteral("tvPkgFileList"));
   tvPkgFileList->setStyleSheet(StrConstants::getTreeViewCSS());
 
   modelPkgFileList->setSortRole(0);
@@ -708,7 +708,7 @@ void MainWindow::initTabOutput()
   gridLayoutX->setSpacing ( 0 );
   gridLayoutX->setMargin ( 0 );
   QTextBrowser *text = new QTextBrowser(tabOutput);
-  text->setObjectName("textBrowser");
+  text->setObjectName(QStringLiteral("textBrowser"));
   text->setReadOnly(true);
   text->setOpenLinks(false);
   text->setFrameShape(QFrame::NoFrame);
@@ -740,7 +740,7 @@ void MainWindow::initTabOutput()
  */
 void MainWindow::initActions()
 {
-  m_hasSLocate = UnixCommand::hasTheExecutable("slocate");
+  m_hasSLocate = UnixCommand::hasTheExecutable(QStringLiteral("slocate"));
   m_hasMirrorCheck = UnixCommand::hasTheExecutable(ctn_MIRROR_CHECK_APP);
   m_actionSysInfo = new QAction(this);
   m_actionMenuMirrorCheck = new QAction(this);
@@ -761,7 +761,7 @@ void MainWindow::initActions()
   if(m_hasMirrorCheck)
   {
     m_actionMenuMirrorCheck->setShortcut(QKeySequence(Qt::ControlModifier|Qt::ShiftModifier|Qt::Key_M));
-    m_actionMenuMirrorCheck->setText("Mirror-Check");
+    m_actionMenuMirrorCheck->setText(QStringLiteral("Mirror-Check"));
     m_actionMenuMirrorCheck->setIcon(IconHelper::getIconMirrorCheck());
     connect(m_actionMenuMirrorCheck, SIGNAL(triggered()), this, SLOT(doMirrorCheck()));
   }  
@@ -812,7 +812,7 @@ void MainWindow::initActions()
   connect(m_actionShowGroups, SIGNAL(triggered()), this, SLOT(hideGroupsWidget()));
 
   m_actionEditOctopiConf = new QAction(this);
-  m_actionEditOctopiConf->setText("octopi.conf...");
+  m_actionEditOctopiConf->setText(QStringLiteral("octopi.conf..."));
   m_actionEditOctopiConf->setIcon(IconHelper::getIconBinary());
   connect(m_actionEditOctopiConf, SIGNAL(triggered()), this, SLOT(editOctopiConf()));
 

--- a/src/mainwindow_init.cpp
+++ b/src/mainwindow_init.cpp
@@ -323,7 +323,7 @@ void MainWindow::initToolBar()
     m_separatorForActionAUR = ui->mainToolBar->addSeparator();
     ui->mainToolBar->addAction(m_actionSwitchToAURTool);
     if (SettingsManager::getAURTool() != ctn_NO_AUR_TOOL)
-      m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->toolTip() + "  (Ctrl+Shift+Y)");
+      m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->toolTip() + QLatin1String("  (Ctrl+Shift+Y)"));
   }
 
   m_dummyAction = new QAction(this);
@@ -331,7 +331,7 @@ void MainWindow::initToolBar()
   ui->mainToolBar->addAction(m_dummyAction);
 
   m_leFilterPackage->setMinimumHeight(24);
-  m_leFilterPackage->setPlaceholderText(m_leFilterPackage->placeholderText() + "  (Ctrl+L)");
+  m_leFilterPackage->setPlaceholderText(m_leFilterPackage->placeholderText() + QLatin1String("  (Ctrl+L)"));
   ui->mainToolBar->addWidget(m_leFilterPackage);
 
   QWidget * hSpacer = new QWidget(this);
@@ -339,7 +339,7 @@ void MainWindow::initToolBar()
   hSpacer->setMinimumWidth(3);
   hSpacer->setVisible(true);
   ui->mainToolBar->addWidget(hSpacer);
-  m_actionShowGroups->setToolTip(m_actionShowGroups->toolTip() + "  (F9)");
+  m_actionShowGroups->setToolTip(m_actionShowGroups->toolTip() + QLatin1String("  (F9)"));
   ui->mainToolBar->addAction(m_actionShowGroups);
   ui->mainToolBar->toggleViewAction()->setEnabled(false);
   ui->mainToolBar->toggleViewAction()->setVisible(false);
@@ -913,21 +913,21 @@ void MainWindow::initActions()
   if (WMHelper::isXFCERunning())
   {
     //Loop through all actions and set their icons (if any) visible to menus.
-    foreach(QAction* ac, this->findChildren<QAction*>(QRegularExpression("(m_a|a)ction\\S*")))
+    foreach(QAction* ac, this->findChildren<QAction*>(QRegularExpression(QLatin1String("(m_a|a)ction\\S*"))))
     {
       if (ac) ac->setIconVisibleInMenu(true);
     }
   }
 
   QString text;
-  foreach(QAction* ac, this->findChildren<QAction*>(QRegularExpression("(m_a|a)ction\\S*")))
+  foreach(QAction* ac, this->findChildren<QAction*>(QRegularExpression(QLatin1String("(m_a|a)ction\\S*"))))
   {
     //text = ac->text().remove("&");
     //ac->setText(qApp->translate("MainWindow", text.toUtf8(), 0));
 
     if (!ac->shortcut().isEmpty())
     {
-      ac->setToolTip(ac->toolTip() + "  (" + ac->shortcut().toString() + ")");
+      ac->setToolTip(ac->toolTip() + QLatin1String("  (") + ac->shortcut().toString() + QLatin1String(")"));
     }
   }
 

--- a/src/mainwindow_news.cpp
+++ b/src/mainwindow_news.cpp
@@ -67,27 +67,27 @@ void MainWindow::refreshDistroNews(bool searchForLatestNews, bool gotoNewsTab)
                         distro == ectn_ARCHBANGLINUX /*||
                         distro == ectn_SWAGARCH*/))
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("Arch Linux") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Arch Linux")) + "</b>");
     }
     else if (gotoNewsTab && distro == ectn_CHAKRA)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("Chakra") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Chakra")) + "</b>");
     }
     else if (gotoNewsTab && distro == ectn_CONDRESOS)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("Condres OS") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Condres OS")) + "</b>");
     }
     else if (gotoNewsTab && distro == ectn_ENDEAVOUROS)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("EndeavourOS") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("EndeavourOS")) + "</b>");
     }
     else if (gotoNewsTab && distro == ectn_KAOS)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("KaOS") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("KaOS")) + "</b>");
     }
     else if (gotoNewsTab && distro == ectn_MANJAROLINUX)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("Manjaro Linux") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Manjaro Linux")) + "</b>");
     }
     /*else if (gotoNewsTab && distro == ectn_NETRUNNER)
     {
@@ -95,7 +95,7 @@ void MainWindow::refreshDistroNews(bool searchForLatestNews, bool gotoNewsTab)
     }*/
     else if (gotoNewsTab && distro == ectn_PARABOLA)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg("Parabola GNU/Linux-libre") + "</b>");
+      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Parabola GNU/Linux-libre")) + "</b>");
     }
 
     /*
@@ -120,7 +120,7 @@ void MainWindow::refreshDistroNews(bool searchForLatestNews, bool gotoNewsTab)
 void MainWindow::postRefreshDistroNews()
 {
   showDistroNews(g_fwDistroNews.result(), true); 
-  if (ui->twProperties->tabText(ctn_TABINDEX_NEWS).contains("**"))
+  if (ui->twProperties->tabText(ctn_TABINDEX_NEWS).contains(QLatin1String("**")))
   {
     ui->twProperties->setCurrentIndex(ctn_TABINDEX_NEWS);
   }
@@ -170,7 +170,7 @@ void MainWindow::showDistroNews(QString distroRSSXML, bool searchForLatestNews)
   }
 
   //Now that we have the html table code, let's put it into TextBrowser's News tab
-  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_NEWS)->findChild<QTextBrowser*>("textBrowser");
+  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_NEWS)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (text)
   {
     text->clear();
@@ -198,7 +198,7 @@ void MainWindow::onTabNewsSourceChanged(QUrl newSource)
   if(newSource.isRelative())
   {
     //If the user clicked a relative and impossible to display link...
-    QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_NEWS)->findChild<QTextBrowser*>("textBrowser");
+    QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_NEWS)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
     if (text)
     {
       disconnect(text, SIGNAL(sourceChanged(QUrl)), this, SLOT(onTabNewsSourceChanged(QUrl)));
@@ -220,7 +220,7 @@ void MainWindow::initTabNews()
   gridLayoutX->setMargin(0);
 
   QTextBrowser *text = new QTextBrowser(tabNews);
-  text->setObjectName("textBrowser");
+  text->setObjectName(QStringLiteral("textBrowser"));
   text->setReadOnly(true);
   text->setFrameShape(QFrame::NoFrame);
   text->setFrameShadow(QFrame::Plain);

--- a/src/mainwindow_news.cpp
+++ b/src/mainwindow_news.cpp
@@ -67,27 +67,27 @@ void MainWindow::refreshDistroNews(bool searchForLatestNews, bool gotoNewsTab)
                         distro == ectn_ARCHBANGLINUX /*||
                         distro == ectn_SWAGARCH*/))
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Arch Linux")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Arch Linux")) + QLatin1String("</b>"));
     }
     else if (gotoNewsTab && distro == ectn_CHAKRA)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Chakra")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Chakra")) + QLatin1String("</b>"));
     }
     else if (gotoNewsTab && distro == ectn_CONDRESOS)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Condres OS")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Condres OS")) + QLatin1String("</b>"));
     }
     else if (gotoNewsTab && distro == ectn_ENDEAVOUROS)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("EndeavourOS")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("EndeavourOS")) + QLatin1String("</b>"));
     }
     else if (gotoNewsTab && distro == ectn_KAOS)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("KaOS")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("KaOS")) + QLatin1String("</b>"));
     }
     else if (gotoNewsTab && distro == ectn_MANJAROLINUX)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Manjaro Linux")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Manjaro Linux")) + QLatin1String("</b>"));
     }
     /*else if (gotoNewsTab && distro == ectn_NETRUNNER)
     {
@@ -95,7 +95,7 @@ void MainWindow::refreshDistroNews(bool searchForLatestNews, bool gotoNewsTab)
     }*/
     else if (gotoNewsTab && distro == ectn_PARABOLA)
     {
-      writeToTabOutput("<b>" + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Parabola GNU/Linux-libre")) + "</b>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getSearchingForDistroNews().arg(QStringLiteral("Parabola GNU/Linux-libre")) + QLatin1String("</b>"));
     }
 
     /*
@@ -135,7 +135,7 @@ void MainWindow::showDistroNews(QString distroRSSXML, bool searchForLatestNews)
 
   if (distroRSSXML.count() >= 200)
   {
-    if (distroRSSXML.at(0)=='*')
+    if (distroRSSXML.at(0)==QLatin1Char('*'))
     {
       /* If this is an updated RSS, we must warn the user!
        And if the main window is hidden... */
@@ -144,7 +144,7 @@ void MainWindow::showDistroNews(QString distroRSSXML, bool searchForLatestNews)
         show();
       }
 
-      ui->twProperties->setTabText(ctn_TABINDEX_NEWS, "** " + StrConstants::getTabNewsName() + " **");
+      ui->twProperties->setTabText(ctn_TABINDEX_NEWS, QLatin1String("** ") + StrConstants::getTabNewsName() + QLatin1String(" **"));
       if (m_gotoNewsTab)
       {
         ui->twProperties->setCurrentIndex(ctn_TABINDEX_NEWS);

--- a/src/mainwindow_refresh.cpp
+++ b/src/mainwindow_refresh.cpp
@@ -78,7 +78,7 @@ void MainWindow::refreshMenuTools()
   {
     ui->menuTools->menuAction()->setVisible(true);
     if (!m_actionMenuMirrorCheck->toolTip().contains(QLatin1String("(")))
-      m_actionMenuMirrorCheck->setToolTip(m_actionMenuMirrorCheck->toolTip() + "  (" + m_actionMenuMirrorCheck->shortcut().toString() + ")" );
+      m_actionMenuMirrorCheck->setToolTip(m_actionMenuMirrorCheck->toolTip() + QLatin1String("  (") + m_actionMenuMirrorCheck->shortcut().toString() + QLatin1Char(')') );
     m_actionMenuMirrorCheck->setVisible(true);
   }
   else
@@ -167,7 +167,7 @@ void MainWindow::refreshGroupsWidget()
   QList<QTreeWidgetItem *> items;
   ui->twGroups->clear();
 
-  items.append(new QTreeWidgetItem(static_cast<QTreeWidget*>(nullptr), QStringList("<" + StrConstants::getDisplayAllGroups() + ">")));
+  items.append(new QTreeWidgetItem(static_cast<QTreeWidget*>(nullptr), QStringList(QLatin1Char('<') + StrConstants::getDisplayAllGroups() + QLatin1Char('>'))));
   m_AllGroupsItem = items.at(0);
   const QStringList*const packageGroups = Package::getPackageGroups();
   foreach(QString group, *packageGroups)
@@ -761,7 +761,7 @@ void MainWindow::showPackagesWithNoDescription()
   {
     PackageListData pld = *it;
 
-    if (pld.description == (pld.name + "  "))
+    if (pld.description == (pld.name + QLatin1String("  ")))
     {
       if (!printHeader)
       {
@@ -1223,7 +1223,7 @@ void MainWindow::showToolButtonAUR()
     }
     else
     {
-      m_toolButtonAUR->setText("(" + QString::number(m_outdatedAURPackagesNameVersion->count()) + ")");
+      m_toolButtonAUR->setText(QLatin1Char('(') + QString::number(m_outdatedAURPackagesNameVersion->count()) + QLatin1Char(')'));
       m_toolButtonAUR->setToolTip(
           StrConstants::getNewUpdates(m_outdatedAURPackagesNameVersion->count()));
     }
@@ -1363,7 +1363,7 @@ void MainWindow::refreshStatusBar()
     }
     else
     {
-      m_toolButtonPacman->setText("(" + QString::number(m_numberOfOutdatedPackages) + ")");
+      m_toolButtonPacman->setText(QLatin1Char('(') + QString::number(m_numberOfOutdatedPackages) + QLatin1Char(')'));
       m_toolButtonPacman->setToolTip(StrConstants::getNewUpdates(m_numberOfOutdatedPackages));
     }
 
@@ -1441,7 +1441,7 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
   }
 
   //If we are trying to refresh an already displayed package...
-  if (m_cachedPackageInInfo == package->repository+"#"+package->name+"#"+package->version)
+  if (m_cachedPackageInInfo == package->repository+QLatin1Char('#')+package->name+QLatin1Char('#')+package->version)
   {
     if (neverQuit)
     {
@@ -1459,7 +1459,7 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
   if (isAURGroupSelected() && package->installed() == false)
   {
     QString aux_desc = package->description;
-    int space = aux_desc.indexOf(' ');
+    int space = aux_desc.indexOf(QLatin1Char(' '));
     QString pkgDescription = aux_desc.mid(space+1);
     QString version = StrConstants::getVersion();
     QTextBrowser*const text = ui->twProperties->widget(
@@ -1486,19 +1486,19 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
       QString anchorBegin = QStringLiteral("anchorBegin");
 
       html += QLatin1String("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
-      html += "<a id=\"" + anchorBegin + "\"></a>";            
+      html += QLatin1String("<a id=\"") + anchorBegin + QLatin1String("\"></a>");
 
       if (UnixCommand::getLinuxDistro() != ectn_KAOS && UnixCommand::getLinuxDistro() != ectn_CHAKRA)
-        html += "<h2><a href=\"https://aur.archlinux.org/packages/" + pkgName + "\">" + pkgName + "</a></h2>";
+        html += QLatin1String("<h2><a href=\"https://aur.archlinux.org/packages/") + pkgName + QLatin1String("\">") + pkgName + QLatin1String("</a></h2>");
       else
-        html += "<h2>" + pkgName + "</h2>";
+        html += QLatin1String("<h2>") + pkgName + QLatin1String("</h2>");
 
       if (Package::getForeignRepositoryToolName() != ctn_KCP_TOOL)
       {
-        html += "<a style=\"font-size:16px;\">" + pkgDescription + "</a>";
+        html += QLatin1String("<a style=\"font-size:16px;\">") + pkgDescription + QLatin1String("</a>");
         html += QLatin1String("<table border=\"0\">");
         html += QLatin1String("<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>");
-        html += "<tr><td>" + version + "</td><td>" + package->version + "</td></tr>";        
+        html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + package->version + QLatin1String("</td></tr>");
 
         if (Package::getForeignRepositoryToolName() == ctn_YAOURT_TOOL ||
             Package::getForeignRepositoryToolName() == ctn_PACAUR_TOOL)
@@ -1506,29 +1506,29 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
           QString url = Package::getAURUrl(pkgName);
           if (!url.isEmpty() && !url.contains(QLatin1String("(null)")))
           {
-            html += "<tr><td>" + StrConstants::getURL() + "</td><td>" + url + "</td></tr>";
+            html += QLatin1String("<tr><td>") + StrConstants::getURL() + QLatin1String("</td><td>") + url + QLatin1String("</td></tr>");
           }
         }
       }
       else if (Package::getForeignRepositoryToolName() == ctn_KCP_TOOL)
       {
-        html += "<a style=\"font-size:16px;\">" + kcp.description + "</a>";
+        html += QLatin1String("<a style=\"font-size:16px;\">") + kcp.description + QLatin1String("</a>");
         html += QLatin1String("<table border=\"0\">");
         html += QLatin1String("<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>");
-        html += "<tr><td>" + version + "</td><td>" + package->version + "</td></tr>";
+        html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + package->version + QLatin1String("</td></tr>");
 
         if (kcp.url != QLatin1String("--"))
-          html += "<tr><td>" + StrConstants::getURL() + "</td><td>" + kcp.url + "</td></tr>";
+          html += QLatin1String("<tr><td>") + StrConstants::getURL() + QLatin1String("</td><td>") + kcp.url + QLatin1String("</td></tr>");
 
         if (kcp.license != QLatin1String("--"))
-          html += "<tr><td>" + StrConstants::getLicenses() + "</td><td>" + kcp.license + "</td></tr>";
+          html += QLatin1String("<tr><td>") + StrConstants::getLicenses() + QLatin1String("</td><td>") + kcp.license + QLatin1String("</td></tr>");
 
         if (kcp.provides != QLatin1String("--"))
-          html += "<tr><td>" + StrConstants::getProvides() + "</td><td>" + kcp.provides + "</td></tr>";
+          html += QLatin1String("<tr><td>") + StrConstants::getProvides() + QLatin1String("</td><td>") + kcp.provides + QLatin1String("</td></tr>");
 
         if (kcp.dependsOn != QLatin1String("--"))
-          html += "<tr><td>" + StrConstants::getDependsOn() + "</td><td>" +
-              Package::makeAnchorOfPackage(kcp.dependsOn) + "</td></tr>";
+          html += QLatin1String("<tr><td>") + StrConstants::getDependsOn() + QLatin1String("</td><td>") +
+              Package::makeAnchorOfPackage(kcp.dependsOn) + QLatin1String("</td></tr>");
       }
 
       html += QLatin1String("</table>");
@@ -1549,7 +1549,7 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
     }
   }
 
-  m_cachedPackageInInfo = package->repository+"#"+package->name+"#"+package->version;
+  m_cachedPackageInInfo = package->repository+QLatin1Char('#')+package->name+QLatin1String("#")+package->version;
 
   if (neverQuit)
   {
@@ -1603,7 +1603,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
   }
 
   //If we are trying to refresh an already displayed package...
-  if (m_cachedPackageInFiles == package->repository+"#"+package->name+"#"+package->version)
+  if (m_cachedPackageInFiles == package->repository+QLatin1Char('#')+package->name+QLatin1Char('#')+package->version)
   {
     if (neverQuit)
     {
@@ -1659,7 +1659,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
 
     foreach ( QString file, fileList )
     {
-      bool isDir = file.endsWith('/');
+      bool isDir = file.endsWith(QLatin1Char('/'));
       bool isSymLinkToDir = false;
       QString baseFileName = extractBaseFileName(file);
 
@@ -1677,7 +1677,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
       if(isDir){
         if ( first == true ){
           item = new QStandardItem ( IconHelper::getIconFolder(), baseFileName );
-          item->setAccessibleDescription("directory " + item->text());
+          item->setAccessibleDescription(QLatin1String("directory ") + item->text());
           fakeRoot->appendRow ( item );
         }
         else{
@@ -1686,7 +1686,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
           if ( file.contains ( fullPath )) {
             //std::cout << "It contains !!! So " << fullPath.toLatin1().data() << " is its parent." << std::endl;
             item = new QStandardItem ( IconHelper::getIconFolder(), baseFileName );
-            item->setAccessibleDescription("directory " + item->text());
+            item->setAccessibleDescription(QLatin1String("directory ") + item->text());
             lastDir->appendRow ( item );
           }
           else{
@@ -1703,7 +1703,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
             while ( parent != fakeRoot );
 
             item = new QStandardItem ( IconHelper::getIconFolder(), baseFileName );
-            item->setAccessibleDescription("directory " + item->text());
+            item->setAccessibleDescription(QLatin1String("directory ") + item->text());
 
             if ( parent != 0 )
             {
@@ -1723,7 +1723,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
       else if (isSymLinkToDir)
       {
         item = new QStandardItem ( IconHelper::getIconFolder(), baseFileName );
-        item->setAccessibleDescription("directory " + item->text());
+        item->setAccessibleDescription(QLatin1String("directory ") + item->text());
         parent = lastDir;
         if (parent != 0) fullPath = utils::showFullPathOfItem(parent->index());
 
@@ -1746,7 +1746,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
       else
       {
         item = new QStandardItem ( IconHelper::getIconBinary(), baseFileName );
-        item->setAccessibleDescription("file " + item->text());
+        item->setAccessibleDescription(QLatin1String("file ") + item->text());
         parent = lastDir;
         if (parent != 0) fullPath = utils::showFullPathOfItem(parent->index());
 
@@ -1775,7 +1775,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
     modelPkgFileList->setHorizontalHeaderLabels( QStringList() << StrConstants::getContentsOf().arg(pkgName));
   }
 
-  m_cachedPackageInFiles = package->repository+"#"+package->name+"#"+package->version;
+  m_cachedPackageInFiles = package->repository+QLatin1Char('#')+package->name+QLatin1Char('#')+package->version;
 
   if (neverQuit)
   {

--- a/src/mainwindow_refresh.cpp
+++ b/src/mainwindow_refresh.cpp
@@ -74,23 +74,23 @@ void MainWindow::refreshAppIcon()
  */
 void MainWindow::refreshMenuTools()
 {
-  if (UnixCommand::hasTheExecutable("mirror-check"))
+  if (UnixCommand::hasTheExecutable(QStringLiteral("mirror-check")))
   {
     ui->menuTools->menuAction()->setVisible(true);
-    if (!m_actionMenuMirrorCheck->toolTip().contains("("))
+    if (!m_actionMenuMirrorCheck->toolTip().contains(QLatin1String("(")))
       m_actionMenuMirrorCheck->setToolTip(m_actionMenuMirrorCheck->toolTip() + "  (" + m_actionMenuMirrorCheck->shortcut().toString() + ")" );
     m_actionMenuMirrorCheck->setVisible(true);
   }
   else
     m_actionMenuMirrorCheck->setVisible(false);
 
-  if(UnixCommand::hasTheExecutable("plv"))
+  if(UnixCommand::hasTheExecutable(QStringLiteral("plv")))
   {
     static bool connectorPlv=false;
 
     ui->menuTools->menuAction()->setVisible(true);
     ui->actionPacmanLogViewer->setVisible(true);
-    ui->actionPacmanLogViewer->setIcon(QIcon::fromTheme("plv"));
+    ui->actionPacmanLogViewer->setIcon(QIcon::fromTheme(QStringLiteral("plv")));
 
     if (!connectorPlv)
     {
@@ -101,7 +101,7 @@ void MainWindow::refreshMenuTools()
   else
     ui->actionPacmanLogViewer->setVisible(false);
 
-  if(UnixCommand::hasTheExecutable("octopi-repoeditor") && UnixCommand::getLinuxDistro() != ectn_KAOS)
+  if(UnixCommand::hasTheExecutable(QStringLiteral("octopi-repoeditor")) && UnixCommand::getLinuxDistro() != ectn_KAOS)
   {
     static bool connectorRepo=false;
 
@@ -117,7 +117,7 @@ void MainWindow::refreshMenuTools()
   else
     ui->actionRepositoryEditor->setVisible(false);
 
-  if(UnixCommand::hasTheExecutable("octopi-cachecleaner"))
+  if(UnixCommand::hasTheExecutable(QStringLiteral("octopi-cachecleaner")))
   {
     static bool connectorCleaner=false;
 
@@ -139,7 +139,7 @@ void MainWindow::refreshMenuTools()
     static bool connectorSysInfo=false;
 
     ui->menuTools->addSeparator();
-    m_actionSysInfo->setText("SysInfo...");
+    m_actionSysInfo->setText(QStringLiteral("SysInfo..."));
     ui->menuTools->addAction(m_actionSysInfo);
 
     if (!connectorSysInfo)
@@ -188,10 +188,10 @@ void MainWindow::refreshGroupsWidget()
 void MainWindow::AURToolSelected()
 {
   //If the system does not have any AUR tool, let's ask if user wants to get one
-  if (m_actionSwitchToAURTool->toolTip() == "AUR" && UnixCommand::getAvailableAURTools().count() ==1)
+  if (m_actionSwitchToAURTool->toolTip() == QLatin1String("AUR") && UnixCommand::getAvailableAURTools().count() ==1)
   {
     //Are we inside a 64bit platform?
-    if (QSysInfo::buildCpuArchitecture() == "x86_64")
+    if (QSysInfo::buildCpuArchitecture() == QLatin1String("x86_64"))
     {
       //We can offer to install a temporary yay-bin and then get yay-bin package
       QMessageBox::StandardButton r = QMessageBox::question(this, StrConstants::getConfirmation(),
@@ -212,7 +212,7 @@ void MainWindow::AURToolSelected()
 
     return;
   }
-  else if (m_actionSwitchToAURTool->toolTip() == "AUR" && UnixCommand::getAvailableAURTools().count() >1)
+  else if (m_actionSwitchToAURTool->toolTip() == QLatin1String("AUR") && UnixCommand::getAvailableAURTools().count() >1)
   {
     onOptions(ectn_TAB_AUR);
     return;
@@ -281,7 +281,7 @@ void MainWindow::AURToolSelected()
       lightPackageFilterConnected = true;
     }
 
-    m_packageModel->applyFilter("");
+    m_packageModel->applyFilter(QLatin1String(""));
     ui->tvPackages->setModel(&emptyModel);
     removePackageTreeViewConnections();
     //m_actionSwitchToAURTool->setEnabled(false);
@@ -297,14 +297,14 @@ void MainWindow::AURToolSelected()
     clearStatusBar();
   }
 
-  m_cachedPackageInInfo="";
+  m_cachedPackageInInfo=QLatin1String("");
 
   //Let's clear the list of visited packages (pkg anchors in Info tab)
   m_listOfVisitedPackages.clear();
   m_indOfVisitedPackage = 0;
 
   switchToViewAllPackages();
-  m_selectedRepository = "";
+  m_selectedRepository = QLatin1String("");
   m_actionRepositoryAll->setChecked(true);
   m_refreshPackageLists = false;
 
@@ -325,7 +325,7 @@ void MainWindow::groupItemSelected()
 {
   //Let us select ALL pkgs from ALL repos!
   switchToViewAllPackages();
-  m_selectedRepository = "";
+  m_selectedRepository = QLatin1String("");
   m_actionRepositoryAll->setChecked(true);
 
   if (m_actionShowGroups->isChecked() && isAllGroupsSelected())
@@ -405,7 +405,7 @@ void MainWindow::buildPackagesFromGroupList(const QString &group)
   m_progressWidget->close();
 
   m_packageRepo.checkAndSetMembersOfGroup(group, *list);
-  m_packageModel->applyFilter(m_selectedViewOption, m_selectedRepository, isAllGroups(group) ? "" : group);
+  m_packageModel->applyFilter(m_selectedViewOption, m_selectedRepository, isAllGroups(group) ? QLatin1String("") : group);
 
   //Refresh counters
   m_numberOfInstalledPackages = installedCount;
@@ -754,7 +754,7 @@ void MainWindow::metaBuildPackageList()
 void MainWindow::showPackagesWithNoDescription()
 {
   bool printHeader = false;
-  QList<PackageListData> *list = Package::getPackageList("", m_checkUpdatesNameNewVersion);
+  QList<PackageListData> *list = Package::getPackageList(QLatin1String(""), m_checkUpdatesNameNewVersion);
   QList<PackageListData>::const_iterator it = list->begin();
 
   while(it != list->end())
@@ -888,8 +888,8 @@ void MainWindow::buildPackageList()
     m_packageModel->applyFilter(PackageModel::ctn_PACKAGE_NAME_COLUMN);
   }
 
-  if (isAllGroupsSelected()) m_packageModel->applyFilter(m_selectedViewOption, m_selectedRepository, "");
-  if (m_leFilterPackage->text() != "") reapplyPackageFilter();
+  if (isAllGroupsSelected()) m_packageModel->applyFilter(m_selectedViewOption, m_selectedRepository, QLatin1String(""));
+  if (m_leFilterPackage->text() != QLatin1String("")) reapplyPackageFilter();
 
   QModelIndex maux = m_packageModel->index(0, 0, QModelIndex());
   ui->tvPackages->setCurrentIndex(maux);
@@ -1171,13 +1171,13 @@ void MainWindow::buildAURPackageList()
 
     int numPkgs = m_packageModel->getPackageCount();
 
-    if (m_leFilterPackage->text() != ""){
+    if (m_leFilterPackage->text() != QLatin1String("")){
       if (numPkgs > 0) m_leFilterPackage->setFoundStyle();
       else m_leFilterPackage->setNotFoundStyle();
     }
     else{
       m_leFilterPackage->initStyleSheet();
-      m_packageModel->applyFilter("");
+      m_packageModel->applyFilter(QLatin1String(""));
     }
   }
   else
@@ -1218,7 +1218,7 @@ void MainWindow::showToolButtonAUR()
   {
     if (m_outdatedAURPackagesNameVersion->count() == 1)
     {
-      m_toolButtonAUR->setText("(1)");
+      m_toolButtonAUR->setText(QStringLiteral("(1)"));
       m_toolButtonAUR->setToolTip(StrConstants::getOneNewUpdate());
     }
     else
@@ -1236,8 +1236,8 @@ void MainWindow::showToolButtonAUR()
   }
   else
   {
-    m_toolButtonAUR->setText("");
-    m_toolButtonAUR->setToolTip("");
+    m_toolButtonAUR->setText(QLatin1String(""));
+    m_toolButtonAUR->setToolTip(QLatin1String(""));
     m_toolButtonAUR->hide();
   }
 
@@ -1262,7 +1262,7 @@ void MainWindow::refreshToolBar()
     {
       //Here the user lost the AUR tool he was using
       m_hasAURTool = true;
-      m_actionSwitchToAURTool->setToolTip("AUR");
+      m_actionSwitchToAURTool->setToolTip(QStringLiteral("AUR"));
       SettingsManager::setAURTool(ctn_NO_AUR_TOOL);
     }
   }
@@ -1340,7 +1340,7 @@ void MainWindow::refreshStatusBar()
     {
       //if (m_packageModel->getPackageCount() == 0)
       {
-        m_lblSelCounter->setText("");
+        m_lblSelCounter->setText(QLatin1String(""));
         m_lblSelCounter->setVisible(false);
         m_lblTotalCounters->setVisible(false);
       }
@@ -1358,7 +1358,7 @@ void MainWindow::refreshStatusBar()
 
     if (m_numberOfOutdatedPackages == 1)
     {
-      m_toolButtonPacman->setText("(1)");
+      m_toolButtonPacman->setText(QStringLiteral("(1)"));
       m_toolButtonPacman->setToolTip(StrConstants::getOneNewUpdate());
     }
     else
@@ -1372,8 +1372,8 @@ void MainWindow::refreshStatusBar()
   else
   {
     m_toolButtonPacman->hide();
-    m_toolButtonPacman->setText("");
-    m_toolButtonPacman->setToolTip("");
+    m_toolButtonPacman->setText(QLatin1String(""));
+    m_toolButtonPacman->setToolTip(QLatin1String(""));
   }
 }
 
@@ -1397,7 +1397,7 @@ void MainWindow::refreshTabInfo(QString pkgName)
 
   CPUIntensiveComputing cic;
   QTextBrowser *text = ui->twProperties->widget(
-        ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>("textBrowser");
+        ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
   if (text)
   {
@@ -1405,7 +1405,7 @@ void MainWindow::refreshTabInfo(QString pkgName)
     text->setHtml(OctopiTabInfo::formatTabInfo(*package, *m_outdatedAURPackagesNameVersion));
     text->scrollToAnchor(OctopiTabInfo::anchorBegin);
     //We have to clear the cached Info contents...
-    m_cachedPackageInInfo = "";
+    m_cachedPackageInInfo = QLatin1String("");
   }
 }
 
@@ -1422,14 +1422,14 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
       selectionModel->selectedRows(PackageModel::ctn_PACKAGE_NAME_COLUMN).count() == 0)
   {
     QTextBrowser *text =
-        ui->twProperties->widget(ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>("textBrowser");
+        ui->twProperties->widget(ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
     if (text)
     {
       text->clear();
     }
 
-    m_cachedPackageInInfo = "";
+    m_cachedPackageInInfo = QLatin1String("");
     return;
   }
 
@@ -1463,7 +1463,7 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
     QString pkgDescription = aux_desc.mid(space+1);
     QString version = StrConstants::getVersion();
     QTextBrowser*const text = ui->twProperties->widget(
-          ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>("textBrowser");
+          ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
     if (text)
     {
@@ -1483,9 +1483,9 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
 
       QString html;
       text->clear();
-      QString anchorBegin = "anchorBegin";
+      QString anchorBegin = QStringLiteral("anchorBegin");
 
-      html += "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
+      html += QLatin1String("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
       html += "<a id=\"" + anchorBegin + "\"></a>";            
 
       if (UnixCommand::getLinuxDistro() != ectn_KAOS && UnixCommand::getLinuxDistro() != ectn_CHAKRA)
@@ -1496,15 +1496,15 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
       if (Package::getForeignRepositoryToolName() != ctn_KCP_TOOL)
       {
         html += "<a style=\"font-size:16px;\">" + pkgDescription + "</a>";
-        html += "<table border=\"0\">";
-        html += "<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>";
+        html += QLatin1String("<table border=\"0\">");
+        html += QLatin1String("<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>");
         html += "<tr><td>" + version + "</td><td>" + package->version + "</td></tr>";        
 
         if (Package::getForeignRepositoryToolName() == ctn_YAOURT_TOOL ||
             Package::getForeignRepositoryToolName() == ctn_PACAUR_TOOL)
         {
           QString url = Package::getAURUrl(pkgName);
-          if (!url.isEmpty() && !url.contains("(null)"))
+          if (!url.isEmpty() && !url.contains(QLatin1String("(null)")))
           {
             html += "<tr><td>" + StrConstants::getURL() + "</td><td>" + url + "</td></tr>";
           }
@@ -1513,25 +1513,25 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
       else if (Package::getForeignRepositoryToolName() == ctn_KCP_TOOL)
       {
         html += "<a style=\"font-size:16px;\">" + kcp.description + "</a>";
-        html += "<table border=\"0\">";
-        html += "<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>";
+        html += QLatin1String("<table border=\"0\">");
+        html += QLatin1String("<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>");
         html += "<tr><td>" + version + "</td><td>" + package->version + "</td></tr>";
 
-        if (kcp.url != "--")
+        if (kcp.url != QLatin1String("--"))
           html += "<tr><td>" + StrConstants::getURL() + "</td><td>" + kcp.url + "</td></tr>";
 
-        if (kcp.license != "--")
+        if (kcp.license != QLatin1String("--"))
           html += "<tr><td>" + StrConstants::getLicenses() + "</td><td>" + kcp.license + "</td></tr>";
 
-        if (kcp.provides != "--")
+        if (kcp.provides != QLatin1String("--"))
           html += "<tr><td>" + StrConstants::getProvides() + "</td><td>" + kcp.provides + "</td></tr>";
 
-        if (kcp.dependsOn != "--")
+        if (kcp.dependsOn != QLatin1String("--"))
           html += "<tr><td>" + StrConstants::getDependsOn() + "</td><td>" +
               Package::makeAnchorOfPackage(kcp.dependsOn) + "</td></tr>";
       }
 
-      html += "</table>";
+      html += QLatin1String("</table>");
       text->setHtml(html);
       text->scrollToAnchor(anchorBegin);
     }
@@ -1539,7 +1539,7 @@ void MainWindow::refreshTabInfo(bool clearContents, bool neverQuit)
   else //We are not in the AUR group
   {
     QTextBrowser *text = ui->twProperties->widget(
-          ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>("textBrowser");
+          ctn_TABINDEX_INFORMATION)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
 
     if (text)
     {
@@ -1579,13 +1579,13 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
       selectionModel->selectedRows(PackageModel::ctn_PACKAGE_NAME_COLUMN).count() == 0)
   {
     QTreeView*const tvPkgFileList =
-        ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+        ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
 
     if(tvPkgFileList)
     {
       QStandardItemModel*const modelPkgFileList = qobject_cast<QStandardItemModel*>(tvPkgFileList->model());
       modelPkgFileList->clear();
-      m_cachedPackageInFiles = "";
+      m_cachedPackageInFiles = QLatin1String("");
       closeTabFilesSearchBar();
       if (filterHasFocus) m_leFilterPackage->setFocus();
       else if (tvPackagesHasFocus) ui->tvPackages->setFocus();
@@ -1612,7 +1612,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
     }
     else
     {
-      QTreeView*const tv = ui->twProperties->currentWidget()->findChild<QTreeView *>("tvPkgFileList") ;
+      QTreeView*const tv = ui->twProperties->currentWidget()->findChild<QTreeView *>(QStringLiteral("tvPkgFileList")) ;
       if (tv)
         tv->scrollTo(tv->currentIndex());
     }
@@ -1624,7 +1624,7 @@ void MainWindow::refreshTabFiles(bool clearContents, bool neverQuit)
   bool nonInstalled = (package->installed() == false);
 
   QTreeView*const tvPkgFileList =
-      ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+      ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
 
   if (tvPkgFileList)
   {
@@ -1803,13 +1803,13 @@ void MainWindow::reapplyPackageFilter()
     m_packageModel->applyFilter(search);
     int numPkgs = m_packageModel->getPackageCount();
 
-    if (m_leFilterPackage->text() != ""){
+    if (m_leFilterPackage->text() != QLatin1String("")){
       if (numPkgs > 0) m_leFilterPackage->setFoundStyle();
       else m_leFilterPackage->setNotFoundStyle();
     }
     else{
       m_leFilterPackage->initStyleSheet();
-      m_packageModel->applyFilter("");
+      m_packageModel->applyFilter(QLatin1String(""));
       refreshStatusBar();
     }
 
@@ -1845,17 +1845,17 @@ void MainWindow::lightPackageFilter()
 {
   if (isAURGroupSelected())
   {
-    if (m_leFilterPackage->text() == "")
+    if (m_leFilterPackage->text() == QLatin1String(""))
     {
       if (UnixCommand::getLinuxDistro() != ectn_KAOS)
       {
-        m_packageModel->applyFilter("ççç");
+        m_packageModel->applyFilter(QStringLiteral("ççç"));
         m_leFilterPackage->initStyleSheet();
         refreshStatusBar();
       }
       else
       {
-        m_packageModel->applyFilter("");
+        m_packageModel->applyFilter(QLatin1String(""));
         reapplyPackageFilter();
         refreshStatusBar();
       }
@@ -1863,10 +1863,10 @@ void MainWindow::lightPackageFilter()
   }
   else if (!isAURGroupSelected())
   {
-    if (m_leFilterPackage->text() == "")
+    if (m_leFilterPackage->text() == QLatin1String(""))
     {
       CPUIntensiveComputing cic;
-      m_packageModel->applyFilter("");
+      m_packageModel->applyFilter(QLatin1String(""));
       reapplyPackageFilter();
       refreshStatusBar();
     }
@@ -1907,7 +1907,7 @@ void MainWindow::selectedNonInstalledPackagesMenu()
 void MainWindow::selectedRepositoryMenu(QAction *actionRepoSelected)
 {
   if (actionRepoSelected->text() == StrConstants::getAll())
-    m_selectedRepository = "";
+    m_selectedRepository = QLatin1String("");
   else
     m_selectedRepository = actionRepoSelected->text();
 

--- a/src/mainwindow_searchbar.cpp
+++ b/src/mainwindow_searchbar.cpp
@@ -33,8 +33,8 @@
  */
 void MainWindow::searchBarTextChangedInTextBrowser(const QString &textToSearch)
 {
-  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>("textBrowser");
-  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
+  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
   utils::searchBarTextChangedInTextBrowser(tb, sb, textToSearch);
 }
@@ -44,8 +44,8 @@ void MainWindow::searchBarTextChangedInTextBrowser(const QString &textToSearch)
  */
 void MainWindow::searchBarFindNextInTextBrowser()
 {
-  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>("textBrowser");
-  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
+  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
   utils::searchBarFindNextInTextBrowser(tb, sb);
 }
@@ -55,8 +55,8 @@ void MainWindow::searchBarFindNextInTextBrowser()
  */
 void MainWindow::searchBarFindPreviousInTextBrowser()
 {
-  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>("textBrowser");
-  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
+  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
   utils::searchBarFindPreviousInTextBrowser(tb, sb);
 }
@@ -66,8 +66,8 @@ void MainWindow::searchBarFindPreviousInTextBrowser()
  */
 void MainWindow::searchBarClosedInTextBrowser()
 {
-  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>("textBrowser");
-  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
+  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
   utils::searchBarClosedInTextBrowser(tb, sb);
 }
@@ -77,8 +77,8 @@ void MainWindow::searchBarClosedInTextBrowser()
  */
 void MainWindow::positionInFirstMatch()
 {
-  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>("textBrowser");
-  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+  QTextBrowser *tb = ui->twProperties->currentWidget()->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
+  SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
   utils::positionInFirstMatch(tb, sb);
 }
@@ -94,12 +94,12 @@ void MainWindow::searchBarTextChangedInTreeView(const QString &textToSearch)
   m_indFoundFilesInPkgFileList = 0;
 
   QTreeView *tvPkgFileList =
-    ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+    ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
   if (tvPkgFileList)
   {
     QStandardItemModel *sim = qobject_cast<QStandardItemModel *>(tvPkgFileList->model());
     if (!sim) return;
-    SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>("searchbar");
+    SearchBar *sb = ui->twProperties->currentWidget()->findChild<SearchBar*>(QStringLiteral("searchbar"));
 
     if (!sb)
       return;
@@ -130,7 +130,7 @@ void MainWindow::searchBarTextChangedInTreeView(const QString &textToSearch)
 void MainWindow::searchBarFindNextInTreeView()
 {
   QTreeView *tvPkgFileList =
-    ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+    ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
 
   if (tvPkgFileList && tvPkgFileList->model()->rowCount() > 0 && m_foundFilesInPkgFileList->count() > 0)
   {
@@ -156,7 +156,7 @@ void MainWindow::searchBarFindNextInTreeView()
 void MainWindow::searchBarFindPreviousInTreeView()
 {
   QTreeView *tvPkgFileList =
-    ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>("tvPkgFileList");
+    ui->twProperties->widget(ctn_TABINDEX_FILES)->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
 
   if (tvPkgFileList && tvPkgFileList->model()->rowCount() > 0 && m_foundFilesInPkgFileList->count() > 0)
   {
@@ -179,7 +179,7 @@ void MainWindow::searchBarFindPreviousInTreeView()
  */
 void MainWindow::searchBarClosedInTreeView()
 {
-  searchBarTextChangedInTreeView("");
-  QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>("tvPkgFileList");
+  searchBarTextChangedInTreeView(QLatin1String(""));
+  QTreeView *tb = ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvPkgFileList"));
   if (tb) tb->setFocus();
 }

--- a/src/mainwindow_transaction.cpp
+++ b/src/mainwindow_transaction.cpp
@@ -226,7 +226,7 @@ QString MainWindow::getTobeRemovedPackages()
 
   for(int c=0; c < siRemoval->rowCount(); c++)
   {
-    res += siRemoval->child(c)->text() + " ";
+    res += siRemoval->child(c)->text() + QLatin1Char(' ');
   }
 
   res = res.trimmed();
@@ -243,7 +243,7 @@ QString MainWindow::getTobeInstalledPackages()
 
   for(int c=0; c < siInstall->rowCount(); c++)
   {
-    res += siInstall->child(c)->text() + " ";
+    res += siInstall->child(c)->text() + QLatin1Char(' ');
   }
 
   res = res.trimmed();
@@ -324,7 +324,7 @@ void MainWindow::insertIntoRemovePackage(QModelIndex *indexToInclude)
         }
       }
 
-      insertRemovePackageIntoTransaction(package->repository + "/" + package->name);
+      insertRemovePackageIntoTransaction(package->repository + QLatin1Char('/') + package->name);
     }
   }
   else
@@ -382,7 +382,7 @@ void MainWindow::insertIntoInstallPackage(QModelIndex *indexToInclude)
       }
 
       insertIntoInstallPackageOptDeps(package->name); //Do we have any deps???
-      insertInstallPackageIntoTransaction(package->repository + "/" + package->name);
+      insertInstallPackageIntoTransaction(package->repository + QLatin1Char('/') + package->name);
     }
   }
   else
@@ -402,7 +402,7 @@ bool MainWindow::isPackageInInstallTransaction(const QString &pkgName)
   QString repo;
 
   if (package != nullptr) repo = package->repository;
-  QList<QStandardItem *> foundItems = sim->findItems(repo + "/" + pkgName, Qt::MatchRecursive | Qt::MatchExactly);
+  QList<QStandardItem *> foundItems = sim->findItems(repo + QLatin1Char('/') + pkgName, Qt::MatchRecursive | Qt::MatchExactly);
 
   return (foundItems.size() > 0);
 }
@@ -447,7 +447,7 @@ void MainWindow::insertIntoInstallPackageOptDeps(const QString &packageName)
   if(optionalPackages.count() > 0)
   {
     MultiSelectionDialog *msd = new MultiSelectionDialog(this);
-    msd->setWindowTitle(packageName + ": " + StrConstants::getOptionalDeps());
+    msd->setWindowTitle(packageName + QLatin1String(": ") + StrConstants::getOptionalDeps());
     msd->setWindowIcon(windowIcon());
     QStringList selectedPackages;
 
@@ -574,7 +574,7 @@ void MainWindow::tvTransactionAdjustItemText(QStandardItem *item)
   }
 
   pos = itemText.indexOf(QLatin1String(")"));
-  itemText.insert(pos, "/" + QString::number(countSelected));
+  itemText.insert(pos, QLatin1Char('/') + QString::number(countSelected));
   item->setText(itemText);
 }
 
@@ -601,7 +601,7 @@ void MainWindow::tvTransactionRowsChanged(const QModelIndex& parent)
   {
     if (item->rowCount() > 0)
     {
-      itemRemove->setText(StrConstants::getTransactionRemoveText() + " (" + count + ")");
+      itemRemove->setText(StrConstants::getTransactionRemoveText() + QLatin1String(" (") + count + QLatin1Char(')'));
       tvTransactionAdjustItemText(itemRemove);
     }
     else itemRemove->setText(StrConstants::getTransactionRemoveText());
@@ -610,7 +610,7 @@ void MainWindow::tvTransactionRowsChanged(const QModelIndex& parent)
   {
     if (item->rowCount() > 0)
     {
-      itemInstall->setText(StrConstants::getTransactionInstallText() + " (" + count + ")");
+      itemInstall->setText(StrConstants::getTransactionInstallText() + QLatin1String(" (") + count + QLatin1Char(')'));
       tvTransactionAdjustItemText(itemInstall);
     }
     else itemInstall->setText(StrConstants::getTransactionInstallText());
@@ -705,7 +705,7 @@ bool MainWindow::isSUAvailable()
   {
     QMessageBox::critical( nullptr, StrConstants::getApplicationName(),
                            StrConstants::getErrorNoSuCommand() +
-                           "\n" + StrConstants::getYoullNeedSuFrontend());
+                           QLatin1Char('\n') + StrConstants::getYoullNeedSuFrontend());
     return false;
   }
 }
@@ -785,7 +785,7 @@ void MainWindow::doAURUpgrade()
     auxPkg.remove(QStringLiteral("[1;39m"));
     auxPkg.remove(QStringLiteral("[0m"));
     auxPkg.remove(QStringLiteral(""));
-    listOfTargets += auxPkg + " ";
+    listOfTargets += auxPkg + QLatin1Char(' ');
   }
 
   disableTransactionActions();
@@ -899,7 +899,7 @@ void MainWindow::doSystemUpgrade(SystemUpgradeOptions systemUpgradeOptions)
     if (targets->count() == 0 && m_outdatedStringList->count() == 0)
     {
       clearTabOutput();
-      writeToTabOutput("<b>" + StrConstants::getNoNewUpdatesAvailable() + "</b><br>");
+      writeToTabOutput(QLatin1String("<b>") + StrConstants::getNoNewUpdatesAvailable() + QLatin1String("</b><br>"));
       return;
     }
     else if (targets->count() < m_outdatedStringList->count())
@@ -909,7 +909,7 @@ void MainWindow::doSystemUpgrade(SystemUpgradeOptions systemUpgradeOptions)
       if (UnixCommand::getTargetUpgradeList().contains("breaks dependency") ||
           UnixCommand::getTargetUpgradeList().contains(": requires "))
       {
-        QString msg = StrConstants::getThereHasBeenATransactionError() + "\n" +
+        QString msg = StrConstants::getThereHasBeenATransactionError() + QLatin1Char('\n') +
             StrConstants::getConfirmExecuteTransactionInTerminal();
 
         int res = QMessageBox::question(this, StrConstants::getConfirmation(),
@@ -957,7 +957,7 @@ void MainWindow::doSystemUpgrade(SystemUpgradeOptions systemUpgradeOptions)
     foreach(PackageListData target, *targets)
     {
       totalDownloadSize += target.downloadSize;
-      list = list + target.name + "-" + target.version + "\n";
+      list = list + target.name + QLatin1Char('-') + target.version + QLatin1Char('\n');
     }
     list.remove(list.size()-1, 1);
 
@@ -970,10 +970,10 @@ void MainWindow::doSystemUpgrade(SystemUpgradeOptions systemUpgradeOptions)
 
     if(targets->count()==1)
       question.setText(StrConstants::getRetrievePackage() +
-                       "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
+                       QLatin1String("\n\n") + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
     else
       question.setText(StrConstants::getRetrievePackages(targets->count()) +
-                       "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
+                       QLatin1String("\n\n") + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
 
     question.setWindowTitle(StrConstants::getConfirmation());
     question.setInformativeText(StrConstants::getConfirmationQuestion());
@@ -1031,7 +1031,7 @@ void MainWindow::doRemoveAndInstall()
   QStringList removeTargets = listOfRemoveTargets.split(QStringLiteral(" "), QString::SkipEmptyParts);
   foreach(QString target, removeTargets)
   {
-    removeList = removeList + StrConstants::getRemove() + " "  + target + "\n";
+    removeList = removeList + StrConstants::getRemove() + QLatin1Char(' ')  + target + QLatin1Char('\n');
   }
 
   QString listOfInstallTargets = getTobeInstalledPackages();
@@ -1042,8 +1042,8 @@ void MainWindow::doRemoveAndInstall()
   foreach(PackageListData installTarget, *installTargets)
   {
     totalDownloadSize += installTarget.downloadSize;
-    installList.append(StrConstants::getInstall() + " " +
-                       installTarget.name + "-" + installTarget.version + "\n");
+    installList.append(StrConstants::getInstall() + QLatin1Char(' ') +
+                       installTarget.name + QLatin1Char('-') + installTarget.version + QLatin1Char('\n'));
     pkgsToInstall.append(installTarget.name);
   }
 
@@ -1055,8 +1055,8 @@ void MainWindow::doRemoveAndInstall()
 
   if (installList.count() == 0)
   {
-    installTargets->append(PackageListData(listOfInstallTargets, QLatin1String(""), nullptr));
-    installList.append(StrConstants::getInstall() + " " + listOfInstallTargets);
+    installTargets->append(PackageListData(listOfInstallTargets, QLatin1String(""), QString::number(0)));
+    installList.append(StrConstants::getInstall() + QLatin1Char(' ') + listOfInstallTargets);
   }
 
   allLists.append(removeList);
@@ -1083,21 +1083,21 @@ void MainWindow::doRemoveAndInstall()
 
   if (removeTargets.count() == 1)
   {
-    dialogText = StrConstants::getRemovePackage() + "\n";
+    dialogText = StrConstants::getRemovePackage() + QLatin1Char('\n');
   }
   else if (removeTargets.count() > 1)
   {
-    dialogText = StrConstants::getRemovePackages(removeTargets.count()) + "\n";
+    dialogText = StrConstants::getRemovePackages(removeTargets.count()) + QLatin1Char('\n');
   }
   if (installTargets->count() == 1)
   {
     dialogText += StrConstants::getRetrievePackage() +
-      "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB"));
+      QLatin1String("\n\n") + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB"));
   }
   else if (installTargets->count() > 1)
   {
     dialogText += StrConstants::getRetrievePackages(installTargets->count()) +
-      "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB"));
+      QLatin1String("\n\n") + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB"));
   }
 
   question.setText(dialogText);
@@ -1152,7 +1152,7 @@ void MainWindow::doRemove()
   QStringList targets = listOfTargets.split(QStringLiteral(" "), QString::SkipEmptyParts);
   foreach(QString target, targets)
   {
-    list = list + target + "\n";
+    list = list + target + QLatin1Char('\n');
   }
 
   TransactionDialog question(this);
@@ -1242,9 +1242,9 @@ void MainWindow::doInstallAURPackage()
 
     if (Package::getForeignRepositoryToolName() != ctn_PACAUR_TOOL &&
         Package::getForeignRepositoryToolName() != ctn_KCP_TOOL)
-      listOfTargets += StrConstants::getForeignRepositoryTargetPrefix() + package->name + " ";
+      listOfTargets += StrConstants::getForeignRepositoryTargetPrefix() + package->name + QLatin1Char(' ');
     else
-      listOfTargets += package->name + " ";
+      listOfTargets += package->name + QLatin1Char(' ');
   }
 
   if (listOfTargets.isEmpty()) {
@@ -1284,7 +1284,7 @@ void MainWindow::doPreDownloadTempYay()
   m_progressWidget->setValue(0);
   m_progressWidget->setMaximum(100);
   clearTabOutput();
-  writeToTabOutput(StrConstants::getDownloadingTempYay() + "<br>");
+  writeToTabOutput(StrConstants::getDownloadingTempYay() + QLatin1String("<br>"));
 
   //Here we start the download thread... and bind its finished state to doInstallYayPackage()
   QFuture<bool> f;
@@ -1305,11 +1305,11 @@ void MainWindow::doInstallYayPackage()
   if (!downloadedYay)
   {
     //We print a message saying the download did not go right
-    writeToTabOutput(StrConstants::getErrorCouldNotDownloadTempYay() + "<br>");
+    writeToTabOutput(StrConstants::getErrorCouldNotDownloadTempYay() + QLatin1String("<br>"));
     enableTransactionActions();
   }
 
-  writeToTabOutput(StrConstants::getTempYayDownloaded() + "<br>");
+  writeToTabOutput(StrConstants::getTempYayDownloaded() + QLatin1String("<br>"));
   m_pacmanExec = new PacmanExec();
   if (m_debugInfo) m_pacmanExec->setDebugMode(true);
 
@@ -1320,7 +1320,7 @@ void MainWindow::doInstallYayPackage()
   QObject::connect(m_pacmanExec, SIGNAL(textToPrintExt(QString)), this, SLOT(outputText(QString)));
   QObject::connect(m_pacmanExec, SIGNAL(commandToExecInQTermWidget(QString)), this, SLOT(onExecCommandInTabTerminal(QString)));
 
-  writeToTabOutput("<b>" + StrConstants::getInstallingPackages() + "</b><br>");
+  writeToTabOutput(QLatin1String("<b>") + StrConstants::getInstallingPackages() + QLatin1String("</b><br>"));
   m_commandExecuting = ectn_INSTALL_YAY;
   m_pacmanExec->doInstallYayUsingTempYay();
 }
@@ -1343,7 +1343,7 @@ void MainWindow::doRemoveAURPackage()
       continue;
     }
 
-    listOfTargets += package->name + " ";
+    listOfTargets += package->name + QLatin1Char(' ');
   }
 
   disableTransactionActions();
@@ -1445,7 +1445,7 @@ void MainWindow::onAURToolChanged()
     }
 
     m_actionSwitchToAURTool->setText(StrConstants::getUseAURTool());
-    m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->text() + "  (Ctrl+Shift+Y)");
+    m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->text() + QLatin1String("  (Ctrl+Shift+Y)"));
     m_refreshForeignPackageList = true;
   }
 
@@ -1544,7 +1544,7 @@ void MainWindow::doInstall()
   {
     totalDownloadSize += target.downloadSize;
     pkgsToInstall.append(target.name);
-    list = list + target.name + "-" + target.version + "\n";
+    list += target.name + QLatin1Char('-') + target.version + QLatin1Char('\n');
   }
 
   list.remove(list.size()-1, 1);
@@ -1555,7 +1555,7 @@ void MainWindow::doInstall()
 
   if (list.count() == 0)
   {
-    targets->append(PackageListData(listOfTargets, QLatin1String(""), nullptr));
+    targets->append(PackageListData(listOfTargets, QLatin1String(""), QString::number(0)));
     list.append(listOfTargets);
   }
 
@@ -1570,11 +1570,11 @@ void MainWindow::doInstall()
       return;
     }
     else question.setText(StrConstants::getRetrievePackage() +
-                          "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
+                          QLatin1String("\n\n") + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
   }
   else
     question.setText(StrConstants::getRetrievePackages(targets->count()) +
-                     "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
+                     QLatin1String("\n\n") + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
 
   question.setWindowTitle(StrConstants::getConfirmation());
   question.setInformativeText(StrConstants::getConfirmationQuestion());
@@ -1627,12 +1627,12 @@ void MainWindow::doInstallLocalPackages()
   foreach(QString target, m_packagesToInstallList)
   {
     fi.setFile(target);
-    list = list + fi.fileName() + "\n";
+    list = list + fi.fileName() + QLatin1Char('\n');
   }
 
   foreach(QString pkgToInstall, m_packagesToInstallList)
   {
-    listOfTargets += pkgToInstall + "; ";
+    listOfTargets += pkgToInstall + QLatin1String("; ");
   }
 
   TransactionDialog question(this);
@@ -1920,7 +1920,7 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
     }
     else if (pkgs.count()==0)
     {
-      writeToTabOutput(StrConstants::getNoUpdatesAvailable() + "<br>");
+      writeToTabOutput(StrConstants::getNoUpdatesAvailable() + QLatin1String("<br>"));
     }
   }
 
@@ -1940,22 +1940,22 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
       foreach(QString dotPacnewFile, dotPacnewFiles)
       {
         if (!dotPacnewFile.contains(QLatin1String("<br>")))
-          writeToTabOutput( "<br>" + dotPacnewFile, ectn_DONT_TREAT_URL_LINK);
+          writeToTabOutput( QLatin1String("<br>") + dotPacnewFile, ectn_DONT_TREAT_URL_LINK);
         else
           writeToTabOutput(dotPacnewFile, ectn_DONT_TREAT_URL_LINK);
       }
     }
 
-    writeToTabOutput("<br><b>" + StrConstants::getCommandFinishedOK() + "</b><br>");
+    writeToTabOutput(QLatin1String("<br><b>") + StrConstants::getCommandFinishedOK() + QLatin1String("</b><br>"));
   }
   else if (exitCode == ctn_PACMAN_PROCESS_EXECUTING)
   {
-    writeToTabOutput(StrConstants::getErrorPacmanProcessExecuting() + "<br>");
-    writeToTabOutput("<br><b>" + StrConstants::getCommandFinishedWithErrors() + "</b><br>");
+    writeToTabOutput(StrConstants::getErrorPacmanProcessExecuting() + QLatin1String("<br>"));
+    writeToTabOutput(QLatin1String("<br><b>") + StrConstants::getCommandFinishedWithErrors() + QLatin1String("</b><br>"));
   }
   else
   {
-    writeToTabOutput("<br><b>" + StrConstants::getCommandFinishedWithErrors() + "</b><br>");
+    writeToTabOutput(QLatin1String("<br><b>") + StrConstants::getCommandFinishedWithErrors() + QLatin1String("</b><br>"));
   }
 
   if(m_commandQueued == ectn_SYSTEM_UPGRADE)
@@ -2077,7 +2077,7 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
     m_actionSwitchToAURTool->setCheckable(true);
     m_actionSwitchToAURTool->setChecked(false);
     m_actionSwitchToAURTool->setText(StrConstants::getUseAURTool());
-    m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->text() + "  (Ctrl+Shift+Y)");
+    m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->text() + QLatin1String("  (Ctrl+Shift+Y)"));
   }
   else if (aurTools.count() > 1) //It seems the AUR tool has just been removed...
   {
@@ -2104,15 +2104,15 @@ void MainWindow::onPressAnyKeyToContinue()
 
   if (m_commandExecuting == ectn_INSTALL_YAY)
   {
-    QString octopiConfDir = QDir::homePath() + QDir::separator() + ".config/octopi";
-    QString yaySymlink = octopiConfDir + QDir::separator() + "yay";
+    QString octopiConfDir = QDir::homePath() + QDir::separator() + QLatin1String(".config/octopi");
+    QString yaySymlink = octopiConfDir + QDir::separator() + QLatin1String("yay");
     QFileInfo info(yaySymlink);
     if (info.isSymLink())
     {
       QFileInfo fi(info.symLinkTarget());
       QFile::remove(yaySymlink);
       QProcess remove;
-      remove.start("rm -Rf " + fi.canonicalPath());
+      remove.start(QLatin1String("rm -Rf ") + fi.canonicalPath());
       remove.waitForFinished();
     }
 
@@ -2121,14 +2121,14 @@ void MainWindow::onPressAnyKeyToContinue()
       refreshHelpUsageText();
       SettingsManager::setAURTool(ctn_YAY_TOOL);
       m_actionSwitchToAURTool->setToolTip(StrConstants::getUseAURTool());
-      m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->toolTip() + "  (Ctrl+Shift+Y)");
+      m_actionSwitchToAURTool->setToolTip(m_actionSwitchToAURTool->toolTip() + QLatin1String("  (Ctrl+Shift+Y)"));
       m_actionSwitchToAURTool->setCheckable(true);
       m_actionSwitchToAURTool->setChecked(false);
-      writeToTabOutput("<br><b>" + StrConstants::getCommandFinishedOK() + "</b><br>");
+      writeToTabOutput(QLatin1String("<br><b>") + StrConstants::getCommandFinishedOK() + QLatin1String("</b><br>"));
     }
     else
     {
-      writeToTabOutput("<br><b>" + StrConstants::getCommandFinishedWithErrors() + "</b><br>");
+      writeToTabOutput(QLatin1String("<br><b>") + StrConstants::getCommandFinishedWithErrors() + QLatin1String("</b><br>"));
     }
   }
 

--- a/src/mainwindow_transaction.cpp
+++ b/src/mainwindow_transaction.cpp
@@ -88,7 +88,7 @@ bool MainWindow::areTherePendingActions()
 QStandardItem * MainWindow::getRemoveTransactionParentItem()
 {
   QTreeView *tvTransaction =
-      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>("tvTransaction");
+      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
   QStandardItemModel *sim = qobject_cast<QStandardItemModel *>(tvTransaction->model());
   QStandardItem *si = nullptr;
 
@@ -106,7 +106,7 @@ QStandardItem * MainWindow::getRemoveTransactionParentItem()
 QStandardItem * MainWindow::getInstallTransactionParentItem()
 {
   QTreeView *tvTransaction =
-      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>("tvTransaction");
+      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
   QStandardItemModel *sim = qobject_cast<QStandardItemModel *>(tvTransaction->model());
   QStandardItem *si = nullptr;
 
@@ -124,20 +124,20 @@ QStandardItem * MainWindow::getInstallTransactionParentItem()
 void MainWindow::insertRemovePackageIntoTransaction(const QString &pkgName)
 {
   QTreeView *tvTransaction =
-      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>("tvTransaction");
+      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
   QStandardItem * siRemoveParent = getRemoveTransactionParentItem();
   QStandardItem * siInstallParent = getInstallTransactionParentItem();
   QStandardItem * siPackageToRemove = new QStandardItem(IconHelper::getIconRemoveItem(), pkgName);
   QStandardItemModel *sim = qobject_cast<QStandardItemModel *>(siRemoveParent->model());
   QList<QStandardItem *> foundItems = sim->findItems(pkgName, Qt::MatchRecursive | Qt::MatchExactly);
 
-  int slash = pkgName.indexOf("/");
+  int slash = pkgName.indexOf(QLatin1String("/"));
   QString pkg = pkgName.mid(slash+1);
   siPackageToRemove->setText(pkg);
 
   if (foundItems.size() == 0)
   {
-    slash = pkgName.indexOf("/");
+    slash = pkgName.indexOf(QLatin1String("/"));
     pkg = pkgName.mid(slash+1);
     QList<QStandardItem *> aux = sim->findItems(pkg, Qt::MatchRecursive | Qt::MatchExactly);
 
@@ -160,7 +160,7 @@ void MainWindow::insertRemovePackageIntoTransaction(const QString &pkgName)
 void MainWindow::insertInstallPackageIntoTransaction(const QString &pkgName)
 {
   QTreeView *tvTransaction =
-      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>("tvTransaction");
+      ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
   QStandardItem * siInstallParent = getInstallTransactionParentItem();
   QStandardItem * siPackageToInstall = new QStandardItem(IconHelper::getIconInstallItem(), pkgName);
   QStandardItem * siRemoveParent = getRemoveTransactionParentItem();
@@ -169,7 +169,7 @@ void MainWindow::insertInstallPackageIntoTransaction(const QString &pkgName)
 
   if (foundItems.size() == 0)
   {
-    int slash = pkgName.indexOf("/");
+    int slash = pkgName.indexOf(QLatin1String("/"));
     QString pkg = pkgName.mid(slash+1);
     QList<QStandardItem *> aux = sim->findItems(pkg, Qt::MatchRecursive | Qt::MatchExactly);
 
@@ -284,7 +284,7 @@ void MainWindow::insertIntoRemovePackage(QModelIndex *indexToInclude)
     }
 
     QString removeCmd = m_removeCommand;
-    if (removeCmd == "Rcs" )
+    if (removeCmd == QLatin1String("Rcs") )
     {
       checkDependencies = true;
     }
@@ -303,9 +303,9 @@ void MainWindow::insertIntoRemovePackage(QModelIndex *indexToInclude)
 
         foreach(QString target, *targets)
         {
-          int separator = target.lastIndexOf("-");
+          int separator = target.lastIndexOf(QLatin1String("-"));
           QString candidate = target.left(separator);
-          separator = candidate.lastIndexOf("-");
+          separator = candidate.lastIndexOf(QLatin1String("-"));
           candidate = candidate.left(separator);
 
           if (candidate != package->name)
@@ -316,7 +316,7 @@ void MainWindow::insertIntoRemovePackage(QModelIndex *indexToInclude)
 
         if (dependencies.count() > 0)
         {
-          if (!dependencies.at(0).contains("HoldPkg was found in"))
+          if (!dependencies.at(0).contains(QLatin1String("HoldPkg was found in")))
           {
             if (!insertIntoRemovePackageDeps(dependencies))
               return;
@@ -433,7 +433,7 @@ void MainWindow::insertIntoInstallPackageOptDeps(const QString &packageName)
   foreach(QString optDep, optDeps)
   {
     QString candidate = optDep;
-    int points = candidate.indexOf(":");
+    int points = candidate.indexOf(QLatin1String(":"));
     candidate = candidate.mid(0, points).trimmed();
     const PackageRepository::PackageData*const package = m_packageRepo.getFirstPackageByName(candidate);
 
@@ -454,7 +454,7 @@ void MainWindow::insertIntoInstallPackageOptDeps(const QString &packageName)
     foreach(const PackageRepository::PackageData* candidate, optionalPackages)
     {
       QString desc = candidate->description;
-      int space = desc.indexOf(" ");
+      int space = desc.indexOf(QLatin1String(" "));
       desc = desc.mid(space+1);
 
       msd->addPackageItem(candidate->name, candidate->description, candidate->repository);
@@ -507,7 +507,7 @@ bool MainWindow::insertIntoRemovePackageDeps(const QStringList &dependencies)
     foreach(const PackageRepository::PackageData* dep, newDeps)
     {
       QString desc = dep->description;
-      int space = desc.indexOf(" ");
+      int space = desc.indexOf(QLatin1String(" "));
       desc = desc.mid(space+1);
 
       /*if(dep->repository == StrConstants::getForeignRepositoryName() && dep->description.isEmpty())
@@ -554,7 +554,7 @@ void MainWindow::tvTransactionAdjustItemText(QStandardItem *item)
 {
   int countSelected=0;
   QTreeView *tvTransaction =
-      ui->twProperties->currentWidget()->findChild<QTreeView*>("tvTransaction");
+      ui->twProperties->currentWidget()->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
   if (!tvTransaction) return;
 
   for(int c=0; c < item->rowCount(); c++)
@@ -566,14 +566,14 @@ void MainWindow::tvTransactionAdjustItemText(QStandardItem *item)
   }
 
   QString itemText = item->text();
-  int slash = itemText.indexOf("/");
-  int pos = itemText.indexOf(")");
+  int slash = itemText.indexOf(QLatin1String("/"));
+  int pos = itemText.indexOf(QLatin1String(")"));
 
   if (slash > 0){
     itemText.remove(slash, pos-slash);
   }
 
-  pos = itemText.indexOf(")");
+  pos = itemText.indexOf(QLatin1String(")"));
   itemText.insert(pos, "/" + QString::number(countSelected));
   item->setText(itemText);
 }
@@ -649,7 +649,7 @@ void MainWindow::onPressDelete()
   else
   {
     QTreeView *tvTransaction =
-        ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>("tvTransaction");
+        ui->twProperties->widget(ctn_TABINDEX_ACTIONS)->findChild<QTreeView*>(QStringLiteral("tvTransaction"));
 
     if (tvTransaction->hasFocus())
     {
@@ -724,7 +724,7 @@ void MainWindow::doCheckUpdates()
 
   //Let's synchronize kcp database too...
   if (UnixCommand::getLinuxDistro() == ectn_KAOS && UnixCommand::hasTheExecutable(ctn_KCP_TOOL))
-    UnixCommand::execCommandAsNormalUser("kcp -u");
+    UnixCommand::execCommandAsNormalUser(QStringLiteral("kcp -u"));
 
   m_commandExecuting = ectn_CHECK_UPDATES;
   disableTransactionActions();
@@ -782,9 +782,9 @@ void MainWindow::doAURUpgrade()
   foreach(QString pkg, *m_outdatedAURStringList)
   {
     auxPkg = pkg;
-    auxPkg.remove("[1;39m");
-    auxPkg.remove("[0m");
-    auxPkg.remove("");
+    auxPkg.remove(QStringLiteral("[1;39m"));
+    auxPkg.remove(QStringLiteral("[0m"));
+    auxPkg.remove(QStringLiteral(""));
     listOfTargets += auxPkg + " ";
   }
 
@@ -874,8 +874,8 @@ void MainWindow::doSystemUpgrade(SystemUpgradeOptions systemUpgradeOptions)
       return;
     }
 
-    if( (m_checkupdatesStringList->count() != 0 && m_checkupdatesStringList->contains("pacman")) ||
-        (m_outdatedStringList->count() != 0 && m_outdatedStringList->contains("pacman")) )
+    if( (m_checkupdatesStringList->count() != 0 && m_checkupdatesStringList->contains(QStringLiteral("pacman"))) ||
+        (m_outdatedStringList->count() != 0 && m_outdatedStringList->contains(QStringLiteral("pacman"))) )
     {
       m_commandExecuting = ectn_RUN_SYSTEM_UPGRADE_IN_TERMINAL;
       m_pacmanExec->doSystemUpgradeInTerminal();
@@ -970,10 +970,10 @@ void MainWindow::doSystemUpgrade(SystemUpgradeOptions systemUpgradeOptions)
 
     if(targets->count()==1)
       question.setText(StrConstants::getRetrievePackage() +
-                       "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(" KB"));
+                       "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
     else
       question.setText(StrConstants::getRetrievePackages(targets->count()) +
-                       "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(" KB"));
+                       "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
 
     question.setWindowTitle(StrConstants::getConfirmation());
     question.setInformativeText(StrConstants::getConfirmationQuestion());
@@ -1028,7 +1028,7 @@ void MainWindow::doRemoveAndInstall()
   TransactionDialog question(this);
   QString dialogText;
 
-  QStringList removeTargets = listOfRemoveTargets.split(" ", QString::SkipEmptyParts);
+  QStringList removeTargets = listOfRemoveTargets.split(QStringLiteral(" "), QString::SkipEmptyParts);
   foreach(QString target, removeTargets)
   {
     removeList = removeList + StrConstants::getRemove() + " "  + target + "\n";
@@ -1055,7 +1055,7 @@ void MainWindow::doRemoveAndInstall()
 
   if (installList.count() == 0)
   {
-    installTargets->append(PackageListData(listOfInstallTargets, "", nullptr));
+    installTargets->append(PackageListData(listOfInstallTargets, QLatin1String(""), nullptr));
     installList.append(StrConstants::getInstall() + " " + listOfInstallTargets);
   }
 
@@ -1064,7 +1064,7 @@ void MainWindow::doRemoveAndInstall()
 
   if(removeTargets.count()==1)
   {
-    if (pRemoveTargets->at(0).indexOf("HoldPkg was found in") != -1)
+    if (pRemoveTargets->at(0).indexOf(QLatin1String("HoldPkg was found in")) != -1)
     {
       QMessageBox::warning(
             this, StrConstants::getAttention(), StrConstants::getWarnHoldPkgFound(), QMessageBox::Ok);
@@ -1073,7 +1073,7 @@ void MainWindow::doRemoveAndInstall()
   }
   else if(installTargets->count()==1)
   {
-    if (installTargets->at(0).name.indexOf("HoldPkg was found in") != -1)
+    if (installTargets->at(0).name.indexOf(QLatin1String("HoldPkg was found in")) != -1)
     {
       QMessageBox::warning(
             this, StrConstants::getAttention(), StrConstants::getWarnHoldPkgFound(), QMessageBox::Ok);
@@ -1092,12 +1092,12 @@ void MainWindow::doRemoveAndInstall()
   if (installTargets->count() == 1)
   {
     dialogText += StrConstants::getRetrievePackage() +
-      "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(" KB");
+      "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB"));
   }
   else if (installTargets->count() > 1)
   {
     dialogText += StrConstants::getRetrievePackages(installTargets->count()) +
-      "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(" KB");
+      "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB"));
   }
 
   question.setText(dialogText);
@@ -1149,7 +1149,7 @@ void MainWindow::doRemove()
   m_targets = Package::getTargetRemovalList(listOfTargets, m_removeCommand);
   QString list;
 
-  QStringList targets = listOfTargets.split(" ", QString::SkipEmptyParts);
+  QStringList targets = listOfTargets.split(QStringLiteral(" "), QString::SkipEmptyParts);
   foreach(QString target, targets)
   {
     list = list + target + "\n";
@@ -1160,7 +1160,7 @@ void MainWindow::doRemove()
   //Shows a dialog indicating the targets which will be removed and asks for the user's permission.
   if(targets.count()==1)
   {
-    if (m_targets->at(0).indexOf("HoldPkg was found in") != -1)
+    if (m_targets->at(0).indexOf(QLatin1String("HoldPkg was found in")) != -1)
     {
       QMessageBox::warning(
             this, StrConstants::getAttention(), StrConstants::getWarnHoldPkgFound(), QMessageBox::Ok);
@@ -1385,7 +1385,7 @@ void MainWindow::onAURToolChanged()
         connect(m_leFilterPackage, SIGNAL(textChanged(QString)), this, SLOT(reapplyPackageFilter()));
       }
 
-      m_packageModel->applyFilter("");
+      m_packageModel->applyFilter(QLatin1String(""));
       static QStandardItemModel emptyModel;
       ui->tvPackages->setModel(&emptyModel);
       removePackageTreeViewConnections();
@@ -1400,14 +1400,14 @@ void MainWindow::onAURToolChanged()
         ui->tvPackages->setColumnHidden(PackageModel::ctn_PACKAGE_SIZE_COLUMN, false);
 
       clearStatusBar();
-      m_cachedPackageInInfo="";
+      m_cachedPackageInInfo=QLatin1String("");
 
       //Let's clear the list of visited packages (pkg anchors in Info tab)
       m_listOfVisitedPackages.clear();
       m_indOfVisitedPackage = 0;
 
       switchToViewAllPackages();
-      m_selectedRepository = "";
+      m_selectedRepository = QLatin1String("");
       m_actionRepositoryAll->setChecked(true);
       m_refreshPackageLists = false;
 
@@ -1428,8 +1428,8 @@ void MainWindow::onAURToolChanged()
     m_outdatedAURPackagesNameVersion->clear();
     m_outdatedAURStringList->clear();
 
-    m_actionSwitchToAURTool->setText("");
-    m_actionSwitchToAURTool->setToolTip("AUR");
+    m_actionSwitchToAURTool->setText(QLatin1String(""));
+    m_actionSwitchToAURTool->setToolTip(QStringLiteral("AUR"));
     m_actionSwitchToAURTool->setCheckable(false);
     m_actionSwitchToAURTool->setChecked(false);
   }
@@ -1555,7 +1555,7 @@ void MainWindow::doInstall()
 
   if (list.count() == 0)
   {
-    targets->append(PackageListData(listOfTargets, "", nullptr));
+    targets->append(PackageListData(listOfTargets, QLatin1String(""), nullptr));
     list.append(listOfTargets);
   }
 
@@ -1563,18 +1563,18 @@ void MainWindow::doInstall()
 
   if(targets->count()==1)
   {
-    if (targets->at(0).name.indexOf("HoldPkg was found in") != -1)
+    if (targets->at(0).name.indexOf(QLatin1String("HoldPkg was found in")) != -1)
     {
       QMessageBox::warning(
             this, StrConstants::getAttention(), StrConstants::getWarnHoldPkgFound(), QMessageBox::Ok);
       return;
     }
     else question.setText(StrConstants::getRetrievePackage() +
-                          "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(" KB"));
+                          "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
   }
   else
     question.setText(StrConstants::getRetrievePackages(targets->count()) +
-                     "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(" KB"));
+                     "\n\n" + StrConstants::getTotalDownloadSize().arg(ds).remove(QStringLiteral(" KB")));
 
   question.setWindowTitle(StrConstants::getConfirmation());
   question.setInformativeText(StrConstants::getConfirmationQuestion());
@@ -1642,7 +1642,7 @@ void MainWindow::doInstallLocalPackages()
 
   if(m_packagesToInstallList.count()==1)
   {
-    if (m_packagesToInstallList.at(0).indexOf("HoldPkg was found in") != -1)
+    if (m_packagesToInstallList.at(0).indexOf(QLatin1String("HoldPkg was found in")) != -1)
     {
       QMessageBox::warning(
             this, StrConstants::getAttention(), StrConstants::getWarnHoldPkgFound(), QMessageBox::Ok);
@@ -1910,7 +1910,7 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
 
       foreach(QString pkg, pkgs)
       {
-        QStringList names = pkg.split(" ", QString::SkipEmptyParts);
+        QStringList names = pkg.split(QStringLiteral(" "), QString::SkipEmptyParts);
         if (names.count() > 0)
         {
           m_checkupdatesStringList->append(names.at(0));
@@ -1929,17 +1929,17 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
        (exitCode == 2 && m_commandExecuting == ectn_CHECK_UPDATES)) && exitStatus == QProcess::NormalExit)
   {
     //First, we empty the tabs cache!
-    m_cachedPackageInInfo = "";
-    m_cachedPackageInFiles = "";
+    m_cachedPackageInInfo = QLatin1String("");
+    m_cachedPackageInFiles = QLatin1String("");
 
     //If there are .pacnew files to print...
     QStringList dotPacnewFiles = m_pacmanExec->getDotPacnewFileList();
     if (dotPacnewFiles.count() > 0)
     {
-      writeToTabOutput("<br>");
+      writeToTabOutput(QStringLiteral("<br>"));
       foreach(QString dotPacnewFile, dotPacnewFiles)
       {
-        if (!dotPacnewFile.contains("<br>"))
+        if (!dotPacnewFile.contains(QLatin1String("<br>")))
           writeToTabOutput( "<br>" + dotPacnewFile, ectn_DONT_TREAT_URL_LINK);
         else
           writeToTabOutput(dotPacnewFile, ectn_DONT_TREAT_URL_LINK);
@@ -1988,7 +1988,7 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
         refreshDistroNews(true, false);
 
         //Did it synchronize any repo? If so, let's refresh some things...
-        if (UnixCommand::isAppRunning("octopi-notifier", true) ||
+        if (UnixCommand::isAppRunning(QStringLiteral("octopi-notifier"), true) ||
             (IsSyncingRepoInTabOutput()))
         {
           bool aurGroup = isAURGroupSelected();
@@ -2046,7 +2046,7 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
     }
   }
 
-  if (exitCode != 0 && (textInTabOutput("conflict"))) //|| _textInTabOutput("could not satisfy dependencies")))
+  if (exitCode != 0 && (textInTabOutput(QStringLiteral("conflict")))) //|| _textInTabOutput("could not satisfy dependencies")))
   {
     int res = QMessageBox::question(this, StrConstants::getThereHasBeenATransactionError(),
                                     StrConstants::getConfirmExecuteTransactionInTerminal(),
@@ -2081,8 +2081,8 @@ void MainWindow::pacmanProcessFinished(int exitCode, QProcess::ExitStatus exitSt
   }
   else if (aurTools.count() > 1) //It seems the AUR tool has just been removed...
   {
-    m_actionSwitchToAURTool->setText("");
-    m_actionSwitchToAURTool->setToolTip("AUR");
+    m_actionSwitchToAURTool->setText(QLatin1String(""));
+    m_actionSwitchToAURTool->setToolTip(QStringLiteral("AUR"));
     m_actionSwitchToAURTool->setCheckable(false);
     m_actionSwitchToAURTool->setChecked(false);
   }
@@ -2116,7 +2116,7 @@ void MainWindow::onPressAnyKeyToContinue()
       remove.waitForFinished();
     }
 
-    if (UnixCommand::hasTheExecutable("yay"))
+    if (UnixCommand::hasTheExecutable(QStringLiteral("yay")))
     {
       refreshHelpUsageText();
       SettingsManager::setAURTool(ctn_YAY_TOOL);
@@ -2162,7 +2162,7 @@ void MainWindow::onPressAnyKeyToContinue()
     delete m_pacmanExec;
 
   m_commandExecuting = ectn_NONE;
-  m_console->execute("");
+  m_console->execute(QLatin1String(""));
   m_console->setFocus();
 
   if (m_cic)
@@ -2195,7 +2195,7 @@ void MainWindow::onCancelControlKey()
  */
 void MainWindow::writeToTabOutput(const QString &msg, TreatURLLinks treatURLLinks)
 {
-  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (text)
   {
     ensureTabVisible(ctn_TABINDEX_OUTPUT);
@@ -2221,7 +2221,7 @@ void MainWindow::incrementPercentage(int percentage)
  */
 void MainWindow::outputText(const QString &output)
 {
-  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>("textBrowser");
+  QTextBrowser *text = ui->twProperties->widget(ctn_TABINDEX_OUTPUT)->findChild<QTextBrowser*>(QStringLiteral("textBrowser"));
   if (text)
   {
     if ((m_commandExecuting == ectn_RUN_IN_TERMINAL && SettingsManager::getTerminal() != ctn_QTERMWIDGET) ||

--- a/src/model/packagemodel.cpp
+++ b/src/model/packagemodel.cpp
@@ -33,7 +33,7 @@ PackageModel::PackageModel(const PackageRepository& repo, QObject *parent)
 : QAbstractItemModel(parent), m_installedPackagesCount(0), m_showColumnPopularity(false), m_packageRepo(repo),
   m_sortOrder(Qt::AscendingOrder), m_sortColumn(1), m_filterPackagesInstalled(false),
   m_filterPackagesNotInstalled(false), m_filterPackagesNotInThisGroup(QLatin1String("")),
-  m_filterColumn(-1), m_filterRegExp("", Qt::CaseInsensitive, QRegExp::RegExp),
+  m_filterColumn(-1), m_filterRegExp(QLatin1String(""), Qt::CaseInsensitive, QRegExp::RegExp),
   m_iconNotInstalled(IconHelper::getIconNonInstalled()), m_iconInstalled(IconHelper::getIconInstalled()),
   m_iconInstalledUnrequired(IconHelper::getIconUnrequired()),
   m_iconNewer(IconHelper::getIconNewer()), m_iconOutdated(IconHelper::getIconOutdated()),
@@ -280,7 +280,7 @@ void PackageModel::applyFilter(ViewOptions pkgViewOptions, const QString& repo, 
   m_filterPackagesNotInThisGroup = group;
 
   QString r = repo;
-  r = r.remove(QRegExp("&"));
+  r = r.remove(QRegExp(QStringLiteral("&")));
   if (r == StrConstants::getAll()) r = QLatin1String("");
 
   m_filterPackagesNotInThisRepo = r;

--- a/src/model/packagemodel.cpp
+++ b/src/model/packagemodel.cpp
@@ -32,7 +32,7 @@
 PackageModel::PackageModel(const PackageRepository& repo, QObject *parent)
 : QAbstractItemModel(parent), m_installedPackagesCount(0), m_showColumnPopularity(false), m_packageRepo(repo),
   m_sortOrder(Qt::AscendingOrder), m_sortColumn(1), m_filterPackagesInstalled(false),
-  m_filterPackagesNotInstalled(false), m_filterPackagesNotInThisGroup(""),
+  m_filterPackagesNotInstalled(false), m_filterPackagesNotInThisGroup(QLatin1String("")),
   m_filterColumn(-1), m_filterRegExp("", Qt::CaseInsensitive, QRegExp::RegExp),
   m_iconNotInstalled(IconHelper::getIconNonInstalled()), m_iconInstalled(IconHelper::getIconInstalled()),
   m_iconInstalledUnrequired(IconHelper::getIconUnrequired()),
@@ -281,7 +281,7 @@ void PackageModel::applyFilter(ViewOptions pkgViewOptions, const QString& repo, 
 
   QString r = repo;
   r = r.remove(QRegExp("&"));
-  if (r == StrConstants::getAll()) r = "";
+  if (r == StrConstants::getAll()) r = QLatin1String("");
 
   m_filterPackagesNotInThisRepo = r;
   endResetRepository();
@@ -348,7 +348,7 @@ const QIcon& PackageModel::getIconFor(const PackageRepository::PackageData& pack
     case ectn_INSTALLED:
       // Does no other package depend on this package ? (unrequired package list)
 
-      if (package.repository != "KCP")
+      if (package.repository != QLatin1String("KCP"))
       {
         if (package.required)
         {

--- a/src/multiselectiondialog.cpp
+++ b/src/multiselectiondialog.cpp
@@ -96,7 +96,7 @@ QStringList MultiSelectionDialog::getSelectedPackages()
     {
       name = ui->twDepPackages->item(row, 0)->text();
       repository = ui->twDepPackages->item(row, 2)->text();
-      result.append(repository + "/" + name);
+      result.append(repository + QLatin1Char('/') + name);
     }
   }
 

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -90,7 +90,7 @@ void OptionsDialog::selRedIconPath()
   if (!leRedIcon->text().isEmpty()) dir = qd.filePath(leRedIcon->text());
 
   QString fileName =
-      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + " (*.bmp *.jpg *.png *.svg *.xmp)");
+      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + QLatin1String(" (*.bmp *.jpg *.png *.svg *.xmp)"));
 
   if (!fileName.isEmpty())
     leRedIcon->setText(fileName);
@@ -106,7 +106,7 @@ void OptionsDialog::selYellowIconPath()
   if (!leYellowIcon->text().isEmpty()) dir = qd.filePath(leYellowIcon->text());
 
   QString fileName =
-      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + " (*.bmp *.jpg *.png *.svg *.xmp)");
+      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + QLatin1String(" (*.bmp *.jpg *.png *.svg *.xmp)"));
 
   if (!fileName.isEmpty())
     leYellowIcon->setText(fileName);
@@ -122,7 +122,7 @@ void OptionsDialog::selGreenIconPath()
   if (!leGreenIcon->text().isEmpty()) dir = qd.filePath(leGreenIcon->text());
 
   QString fileName =
-      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + " (*.bmp *.jpg *.png *.svg *.xmp)");
+      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + QLatin1String(" (*.bmp *.jpg *.png *.svg *.xmp)"));
 
   if (!fileName.isEmpty())
     leGreenIcon->setText(fileName);
@@ -138,7 +138,7 @@ void OptionsDialog::selBusyIconPath()
   if (!leBusyIcon->text().isEmpty()) dir = qd.filePath(leBusyIcon->text());
 
   QString fileName =
-      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + " (*.bmp *.jpg *.png *.svg *.xmp)");
+      QFileDialog::getOpenFileName(this, tr("Open Image"), dir, tr("Image Files") + QLatin1String(" (*.bmp *.jpg *.png *.svg *.xmp)"));
 
   if (!fileName.isEmpty())
     leBusyIcon->setText(fileName);
@@ -808,7 +808,7 @@ void OptionsDialog::onAURConnect()
     else
     {
       QMessageBox::StandardButton r = QMessageBox::question(this, StrConstants::getConfirmation(),
-                            StrConstants::getAURConnectionIsOK() + "\n" +
+                            StrConstants::getAURConnectionIsOK() + QLatin1Char('\n') +
                             StrConstants::getWouldYouLikeToHelpThisProject(),
                             QMessageBox::Yes | QMessageBox::No,
                             QMessageBox::Yes);

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -42,7 +42,7 @@
 OptionsDialog::OptionsDialog(QWidget *parent) :
   QDialog(parent)
 {
-  if (parent->windowTitle() == "Octopi") m_calledByOctopi = true;
+  if (parent->windowTitle() == QLatin1String("Octopi")) m_calledByOctopi = true;
   else m_calledByOctopi = false;
 
   setupUi(this);
@@ -58,7 +58,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
  */
 void OptionsDialog::gotoAURTab()
 {
-  setCurrentIndexByTabName("AUR");
+  setCurrentIndexByTabName(QStringLiteral("AUR"));
 }
 
 /*
@@ -86,7 +86,7 @@ void OptionsDialog::defaultIconChecked(bool checked)
 void OptionsDialog::selRedIconPath()
 {
   QDir qd;
-  QString dir = "/usr/share/icons";
+  QString dir = QStringLiteral("/usr/share/icons");
   if (!leRedIcon->text().isEmpty()) dir = qd.filePath(leRedIcon->text());
 
   QString fileName =
@@ -102,7 +102,7 @@ void OptionsDialog::selRedIconPath()
 void OptionsDialog::selYellowIconPath()
 {
   QDir qd;
-  QString dir = "/usr/share/icons";
+  QString dir = QStringLiteral("/usr/share/icons");
   if (!leYellowIcon->text().isEmpty()) dir = qd.filePath(leYellowIcon->text());
 
   QString fileName =
@@ -118,7 +118,7 @@ void OptionsDialog::selYellowIconPath()
 void OptionsDialog::selGreenIconPath()
 {
   QDir qd;
-  QString dir = "/usr/share/icons";
+  QString dir = QStringLiteral("/usr/share/icons");
   if (!leGreenIcon->text().isEmpty()) dir = qd.filePath(leGreenIcon->text());
 
   QString fileName =
@@ -134,7 +134,7 @@ void OptionsDialog::selGreenIconPath()
 void OptionsDialog::selBusyIconPath()
 {
   QDir qd;
-  QString dir = "/usr/share/icons";
+  QString dir = QStringLiteral("/usr/share/icons");
   if (!leBusyIcon->text().isEmpty()) dir = qd.filePath(leBusyIcon->text());
 
   QString fileName =
@@ -202,11 +202,11 @@ void OptionsDialog::initAURTab()
       UnixCommand::getLinuxDistro() == ectn_CHAKRA ||
       UnixCommand::getLinuxDistro() == ectn_PARABOLA)
   {
-    removeTabByName("AUR");
+    removeTabByName(QStringLiteral("AUR"));
   }
   else
   {
-    lblAURWarning->setStyleSheet("QLabel{ color: red; }");
+    lblAURWarning->setStyleSheet(QStringLiteral("QLabel{ color: red; }"));
     QStringList aurTools=UnixCommand::getAvailableAURTools();
 
     connect(comboAUR, SIGNAL(currentTextChanged(const QString &)), this, SLOT(comboAURChanged(const QString &)));
@@ -392,9 +392,9 @@ void OptionsDialog::accept()
         (!SettingsManager::hasPacmanBackend()) != rbAlpm->isChecked())
     {
       if (rbPacman->isChecked())
-        SettingsManager::setBackend("pacman");
+        SettingsManager::setBackend(QStringLiteral("pacman"));
       else
-        SettingsManager::setBackend("alpm");
+        SettingsManager::setBackend(QStringLiteral("alpm"));
 
       m_backendHasChanged = true;
     }
@@ -520,14 +520,14 @@ void OptionsDialog::accept()
         if (leAurUserName->text().isEmpty())
         {
           delete cic;
-          setCurrentIndexByTabName("AUR");
+          setCurrentIndexByTabName(QStringLiteral("AUR"));
           QMessageBox::critical(this, StrConstants::getError(), StrConstants::getErrorAURUserNameIsNotSet());
           return;
         }
         if (leAurPassword->text().isEmpty())
         {
           delete cic;
-          setCurrentIndexByTabName("AUR");
+          setCurrentIndexByTabName(QStringLiteral("AUR"));
           QMessageBox::critical(this, StrConstants::getError(), StrConstants::getErrorAURPasswordIsNotSet());
           return;
         }
@@ -797,9 +797,9 @@ void OptionsDialog::onAURConnect()
     bool octopiDevVoted=false;
     bool octopiVoted=false;
     bool alpmUtilsVoted=false;
-    if (v.isPkgVoted("octopi-dev")==0) octopiDevVoted=true;
-    if (v.isPkgVoted("octopi")==0) octopiVoted=true;
-    if (v.isPkgVoted("alpm_octopi_utils")==0) alpmUtilsVoted=true;
+    if (v.isPkgVoted(QStringLiteral("octopi-dev"))==0) octopiDevVoted=true;
+    if (v.isPkgVoted(QStringLiteral("octopi"))==0) octopiVoted=true;
+    if (v.isPkgVoted(QStringLiteral("alpm_octopi_utils"))==0) alpmUtilsVoted=true;
 
     if (octopiDevVoted && octopiVoted && alpmUtilsVoted)
     {
@@ -815,9 +815,9 @@ void OptionsDialog::onAURConnect()
       if (r == QMessageBox::Yes)
       {
         //User opted to help the project, so let's vote for the packages
-        if (!octopiDevVoted) v.voteForPkg("octopi-dev");
-        if (!octopiVoted) v.voteForPkg("octopi");
-        if (!alpmUtilsVoted) v.voteForPkg("alpm_octopi_utils");
+        if (!octopiDevVoted) v.voteForPkg(QStringLiteral("octopi-dev"));
+        if (!octopiVoted) v.voteForPkg(QStringLiteral("octopi"));
+        if (!alpmUtilsVoted) v.voteForPkg(QStringLiteral("alpm_octopi_utils"));
 
         //Let's thank user for voting!
         QMessageBox::information(this, StrConstants::getInformation(), StrConstants::getThankYouForVoting());
@@ -833,5 +833,5 @@ void OptionsDialog::onAURConnect()
  */
 void OptionsDialog::onAURRegister()
 {
-  QDesktopServices::openUrl(QUrl("https://aur.archlinux.org/register/"));
+  QDesktopServices::openUrl(QUrl(QStringLiteral("https://aur.archlinux.org/register/")));
 }

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -44,19 +44,19 @@
  */
 QString Package::getBaseName( const QString& p )
 {
-	QString packageBaseName="";
+	QString packageBaseName=QLatin1String("");
 	QString aux(p);
 	int numberOfSegments = p.count('-')+1;
 	int nameSegment = numberOfSegments-3;
 
 	for (int i=1; i<= nameSegment; i++){
-    int a=aux.indexOf("-");
+    int a=aux.indexOf(QLatin1String("-"));
 		packageBaseName += aux.leftRef(a);
-		if (i<nameSegment) packageBaseName += "-";
+		if (i<nameSegment) packageBaseName += QLatin1String("-");
 		aux = aux.mid(a+1);
 	}
 
-	if (packageBaseName == "") packageBaseName += p.leftRef(p.indexOf("-"));
+	if (packageBaseName == QLatin1String("")) packageBaseName += p.leftRef(p.indexOf(QLatin1String("-")));
 	return packageBaseName;
 }
 
@@ -151,11 +151,11 @@ QString Package::makeAnchorOfOptionalDep(const QString &optionalDeps)
   QString newDeps;
   QString newDep;
   QString name;
-  QStringList ldeps = optionalDeps.split("<br>", QString::SkipEmptyParts);
+  QStringList ldeps = optionalDeps.split(QStringLiteral("<br>"), QString::SkipEmptyParts);
 
   foreach(QString dep, ldeps)
   {
-    int colon = dep.indexOf(":");
+    int colon = dep.indexOf(QLatin1String(":"));
     if (colon != -1)
     {
       name = dep.left(colon).trimmed();
@@ -170,7 +170,7 @@ QString Package::makeAnchorOfOptionalDep(const QString &optionalDeps)
     }
   }
 
-  newDeps.remove(QRegularExpression("<br>$"));
+  newDeps.remove(QRegularExpression(QStringLiteral("<br>$")));
   return newDeps;
 }
 
@@ -181,13 +181,13 @@ QString Package::makeAnchorOfPackage(const QString &packages)
 {
   QString newDeps;
   QString newDep;
-  QStringList ldeps = packages.split(" ", QString::SkipEmptyParts);
+  QStringList ldeps = packages.split(QStringLiteral(" "), QString::SkipEmptyParts);
 
   foreach(QString dep, ldeps)
   {
-    if (!dep.contains("=") &&
-        !dep.contains("<") &&
-        !dep.contains(">"))
+    if (!dep.contains(QLatin1String("=")) &&
+        !dep.contains(QLatin1String("<")) &&
+        !dep.contains(QLatin1String(">")))
     {
       newDeps += "<a href=\"goto:" + dep + "\">" + dep + "</a> ";
     }
@@ -195,36 +195,36 @@ QString Package::makeAnchorOfPackage(const QString &packages)
     {
       int p=-1;
 
-      if (dep.contains("<"))
+      if (dep.contains(QLatin1String("<")))
       {
-        if (dep.contains("="))
+        if (dep.contains(QLatin1String("=")))
         {
-          p = dep.indexOf("<");
+          p = dep.indexOf(QLatin1String("<"));
           newDep = dep.left(p);
         }
         else
         {
           newDep = dep.left(p);
-          dep.replace("<", "&lt;");
+          dep.replace(QLatin1String("<"), QLatin1String("&lt;"));
         }
       }
-      else if (dep.contains(">"))
+      else if (dep.contains(QLatin1String(">")))
       {
-        p = dep.indexOf(">");
-        if (dep.contains("="))
+        p = dep.indexOf(QLatin1String(">"));
+        if (dep.contains(QLatin1String("=")))
         {
-          p = dep.indexOf(">");
+          p = dep.indexOf(QLatin1String(">"));
           newDep = dep.left(p);
         }
         else
         {
           newDep = dep.left(p);
-          dep.replace(">", "&gt;");
+          dep.replace(QLatin1String(">"), QLatin1String("&gt;"));
         }
       }
-      else if (dep.contains("="))
+      else if (dep.contains(QLatin1String("=")))
       {
-        p = dep.indexOf("=");
+        p = dep.indexOf(QLatin1String("="));
         newDep = dep.left(p);
       }
 
@@ -247,7 +247,7 @@ QSet<QString>* Package::getUnrequiredPackageList()
   if (SettingsManager::hasPacmanBackend())
   {
     QString unrequiredPkgList = UnixCommand::getUnrequiredPackageList();
-    QStringList packageTuples = unrequiredPkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+    QStringList packageTuples = unrequiredPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
     foreach(QString packageTuple, packageTuples)
     {
@@ -282,7 +282,7 @@ QStringList *Package::getOutdatedStringList()
   if (SettingsManager::hasPacmanBackend())
   {
     QString outPkgList = UnixCommand::getOutdatedPackageList();
-    QStringList packageTuples = outPkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+    QStringList packageTuples = outPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
     QStringList ignorePkgList = UnixCommand::getIgnorePkgsFromPacmanConf();
 
     foreach(QString packageTuple, packageTuples)
@@ -327,16 +327,16 @@ QString Package::removeColorCodesFromStr(const QString &str)
   QString ret = str;
 
   ret = ret.remove("\033");
-  ret = ret.remove("[1;31m");
-  ret = ret.remove("[1;32m");
-  ret = ret.remove("[1;33m");
-  ret = ret.remove("[1;34m");
-  ret = ret.remove("[1;35m");
-  ret = ret.remove("[1;36m");
-  ret = ret.remove("[1;39m");
-  ret = ret.remove("[m");
-  ret = ret.remove("[0m");
-  ret = ret.remove("[1m");
+  ret = ret.remove(QStringLiteral("[1;31m"));
+  ret = ret.remove(QStringLiteral("[1;32m"));
+  ret = ret.remove(QStringLiteral("[1;33m"));
+  ret = ret.remove(QStringLiteral("[1;34m"));
+  ret = ret.remove(QStringLiteral("[1;35m"));
+  ret = ret.remove(QStringLiteral("[1;36m"));
+  ret = ret.remove(QStringLiteral("[1;39m"));
+  ret = ret.remove(QStringLiteral("[m"));
+  ret = ret.remove(QStringLiteral("[0m"));
+  ret = ret.remove(QStringLiteral("[1m"));
   ret = ret.remove("\u001B");
 
   return ret;
@@ -361,7 +361,7 @@ QStringList *Package::getOutdatedAURStringList()
   QString outPkgList = removeColorCodesFromStr(UnixCommand::getOutdatedAURPackageList());
   outPkgList = outPkgList.trimmed();
 
-  QStringList packageTuples = outPkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList packageTuples = outPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList ignorePkgList = UnixCommand::getIgnorePkgsFromPacmanConf();
 
   foreach(QString packageTuple, packageTuples)
@@ -430,7 +430,7 @@ QStringList *Package::getOutdatedAURStringList()
 QStringList *Package::getPackageGroups()
 {
   QString packagesFromGroup = UnixCommand::getPackageGroups();
-  QStringList packageTuples = packagesFromGroup.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList packageTuples = packagesFromGroup.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList * res = new QStringList();
 
   foreach(QString packageTuple, packageTuples)
@@ -453,7 +453,7 @@ QStringList *Package::getPackageGroups()
 QStringList *Package::getPackagesOfGroup(const QString &groupName)
 {
   QString packagesFromGroup = UnixCommand::getPackagesFromGroup(groupName);
-  QStringList packageTuples = packagesFromGroup.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList packageTuples = packagesFromGroup.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList * res = new QStringList();
 
   foreach(QString packageTuple, packageTuples)
@@ -472,27 +472,27 @@ QStringList *Package::getPackagesOfGroup(const QString &groupName)
 QList<PackageListData> *Package::getTargetUpgradeList(const QString &pkgName)
 {
   QString targets = UnixCommand::getTargetUpgradeList(pkgName);
-  QStringList packageTuples = targets.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList packageTuples = targets.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QList<PackageListData> *res = new QList<PackageListData>();
   packageTuples.sort();
 
   foreach(QString packageTuple, packageTuples)
   {
     //TODO: Need to handle when this list has "::" conflict items!
-    if(packageTuple.indexOf("::")!=-1)
+    if(packageTuple.indexOf(QLatin1String("::"))!=-1)
     {
       continue;
     }
 
     PackageListData ld;
-    QStringList data = packageTuple.split(" ");
+    QStringList data = packageTuple.split(QStringLiteral(" "));
     if (data.count() == 3)
     {
       ld = PackageListData(data.at(0), data.at(1), data.at(2));
     }
     else if (data.count() == 1)
     {
-      ld = PackageListData(data.at(0), "", 0);
+      ld = PackageListData(data.at(0), QLatin1String(""), 0);
     }
 
     res->append(ld);
@@ -507,7 +507,7 @@ QList<PackageListData> *Package::getTargetUpgradeList(const QString &pkgName)
 QStringList *Package::getTargetRemovalList(const QString &pkgName, const QString &removeCommand)
 {
   QString targets = UnixCommand::getTargetRemovalList(pkgName, removeCommand);
-  QStringList packageTuples = targets.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList packageTuples = targets.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList * res = new QStringList();
 
   foreach(QString packageTuple, packageTuples)
@@ -529,7 +529,7 @@ QList<PackageListData> *Package::getForeignPackageList()
   if (SettingsManager::hasPacmanBackend())
   {
     QString foreignPkgList = UnixCommand::getForeignPackageList();
-    QStringList packageTuples = foreignPkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+    QStringList packageTuples = foreignPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
     foreach(QString packageTuple, packageTuples)
     {
@@ -537,7 +537,7 @@ QList<PackageListData> *Package::getForeignPackageList()
       if (parts.size() == 2)
       {
         QString desc=parts[0] + " " + Package::getInformationDescription(parts[0], true);
-        res->append(PackageListData(parts[0], "", parts[1], desc, ectn_FOREIGN));
+        res->append(PackageListData(parts[0], QLatin1String(""), parts[1], desc, ectn_FOREIGN));
       }
     }
   }
@@ -573,17 +573,17 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
     QString pkgName, pkgRepository, pkgVersion, pkgDescription, pkgOutVersion;
     PackageStatus pkgStatus;
     QString pkgList = UnixCommand::getPackageList(packageName);
-    QStringList packageTuples = pkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+    QStringList packageTuples = pkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
     if(!pkgList.isEmpty())
     {
-      pkgDescription = "";
+      pkgDescription = QLatin1String("");
       foreach(QString packageTuple, packageTuples)
       {
         if (!packageTuple[0].isSpace())
         {
           //Do we already have a description?
-          if (pkgDescription != "")
+          if (pkgDescription != QLatin1String(""))
           {
             pkgDescription = pkgName + " " + pkgDescription;
 
@@ -595,29 +595,29 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
               res->append(pld);
             }
 
-            pkgDescription = "";
+            pkgDescription = QLatin1String("");
           }
 
           //First we get repository and name!
           QStringList parts = packageTuple.split(' ');
           QString repoName = parts[0];
-          int a = repoName.indexOf("/");
+          int a = repoName.indexOf(QLatin1String("/"));
           pkgRepository = repoName.left(a);
           pkgName = repoName.mid(a+1);
           pkgVersion = parts[1];
 
-          if(packageTuple.indexOf("[installed]") != -1)
+          if(packageTuple.indexOf(QLatin1String("[installed]")) != -1)
           {
             //This is an installed package
             pkgStatus = ectn_INSTALLED;
-            pkgOutVersion = "";
+            pkgOutVersion = QLatin1String("");
           }
-          else if (packageTuple.indexOf("[installed:") != -1)
+          else if (packageTuple.indexOf(QLatin1String("[installed:")) != -1)
           {
             //This is an outdated installed package
             pkgStatus = ectn_OUTDATED;
 
-            int i = packageTuple.indexOf("[installed:");
+            int i = packageTuple.indexOf(QLatin1String("[installed:"));
             pkgOutVersion = packageTuple.mid(i+11);
             pkgOutVersion = pkgOutVersion.remove(']').trimmed();
           }
@@ -625,7 +625,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
           {
             //This is an uninstalled package
             pkgStatus = ectn_NON_INSTALLED;
-            pkgOutVersion = "";
+            pkgOutVersion = QLatin1String("");
           }
         }
         else
@@ -634,7 +634,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
           if (!packageTuple.trimmed().isEmpty())
             pkgDescription += packageTuple.trimmed();
           else
-            pkgDescription += " "; //StrConstants::getNoDescriptionAvailabe();
+            pkgDescription += QLatin1String(" "); //StrConstants::getNoDescriptionAvailabe();
         }
       }
 
@@ -749,7 +749,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
  */
 QString Package::getAURUrl(const QString &pkgName)
 {
-  QString url="";
+  QString url=QLatin1String("");
 
   if (getForeignRepositoryToolName() != ctn_KCP_TOOL)
   {
@@ -780,19 +780,19 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
 
   QString aurTool = getForeignRepositoryToolName();
   QString pkgList = UnixCommand::getAURPackageList(searchString);
-  QStringList packageTuples = pkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList packageTuples = pkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
   if (aurTool == ctn_YAY_TOOL)
   {
     return getYayPackageList(packageTuples);
   }
 
-  pkgDescription = "";
+  pkgDescription = QLatin1String("");
   foreach(QString packageTuple, packageTuples)
   {
     if (packageTuple[0].isNumber())
     {
-      int space=packageTuple.indexOf(" ");
+      int space=packageTuple.indexOf(QLatin1String(" "));
       packageTuple = packageTuple.mid(space+1);
     }
 
@@ -800,7 +800,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
         (UnixCommand::getLinuxDistro() == ectn_KAOS && packageTuple[0] != '\t'))
     {
       //Do we already have a description?
-      if (pkgDescription != "")
+      if (pkgDescription != QLatin1String(""))
       {
         pkgDescription = pkgName + " " + pkgDescription;
 
@@ -810,7 +810,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
         pld.popularity = pkgVotes;
 
         res->append(pld);
-        pkgDescription = "";
+        pkgDescription = QLatin1String("");
       }
 
       //First we get repository and name!
@@ -818,11 +818,11 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
 
       if (UnixCommand::getLinuxDistro() == ectn_KAOS)
       {
-        parts[0] = parts[0].remove("[1;35m");
+        parts[0] = parts[0].remove(QStringLiteral("[1;35m"));
       }
 
       QString repoName = parts[0];
-      int a = repoName.indexOf("/");
+      int a = repoName.indexOf(QLatin1String("/"));
       pkgRepository = repoName.left(a);
 
       if (pkgRepository != StrConstants::getForeignPkgRepositoryName())
@@ -835,10 +835,10 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       pkgName = repoName.mid(a+1);
       pkgVersion = parts[1];
 
-      QStringList strVotes = parts.filter("(");
+      QStringList strVotes = parts.filter(QStringLiteral("("));
       //Let's see if it's not a Trizen style
       if (strVotes.isEmpty())
-        strVotes = parts.filter("+]");
+        strVotes = parts.filter(QStringLiteral("+]"));
 
       pkgVotes = 0;
 
@@ -847,14 +847,14 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       if (aurTool == ctn_TRIZEN_TOOL)
       {
         if (!strVotes.first().isEmpty())
-          pkgVotes = strVotes.first().replace('[', "").replace(']', "").replace('+', "").toInt();
+          pkgVotes = strVotes.first().replace('[', QLatin1String("")).replace(']', QLatin1String("")).replace('+', QLatin1String("")).toInt();
         else
           pkgVotes = 0;
       }
       else if (aurTool != ctn_CHASER_TOOL && aurTool != ctn_PACAUR_TOOL && aurTool != ctn_PIKAUR_TOOL && strVotes.count() > 0)
       {
         if (!strVotes.first().isEmpty())
-          pkgVotes = strVotes.first().replace('(', "").replace(')', "").toInt();
+          pkgVotes = strVotes.first().replace('(', QLatin1String("")).replace(')', QLatin1String("")).toInt();
         else
           pkgVotes = 0;
       }
@@ -863,7 +863,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
         if (!strVotes.first().isEmpty())
         {
           QString str = strVotes.first();
-          int comma = str.indexOf(",");
+          int comma = str.indexOf(QLatin1String(","));
           pkgVotes = str.midRef(1, comma-1).toInt();
         }
         else pkgVotes = 0;
@@ -871,13 +871,13 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
 
       if (aurTool == ctn_PIKAUR_TOOL)
       {
-        if(packageTuple.indexOf(" [") != -1)
+        if(packageTuple.indexOf(QLatin1String(" [")) != -1)
         {
-          if (packageTuple.indexOf("installed: ") != -1)
+          if (packageTuple.indexOf(QLatin1String("installed: ")) != -1)
           {
-            int i = packageTuple.indexOf(": ");
+            int i = packageTuple.indexOf(QLatin1String(": "));
             pkgOutVersion = packageTuple.mid(i+2);
-            pkgOutVersion = pkgOutVersion.remove(QRegularExpression("\\].*")).trimmed();
+            pkgOutVersion = pkgOutVersion.remove(QRegularExpression(QStringLiteral("\\].*"))).trimmed();
 
             //Compare actual and new version
             char const * pkgOutVersion_temp = pkgOutVersion.toStdString().c_str();
@@ -892,36 +892,36 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
             {
               //This is an installed package
               pkgStatus = ectn_FOREIGN;
-              pkgOutVersion = "";
+              pkgOutVersion = QLatin1String("");
             }
           }
           else
           {
             //This is an installed package
             pkgStatus = ectn_FOREIGN;
-            pkgOutVersion = "";
+            pkgOutVersion = QLatin1String("");
           }
         }
         else
         {
           //This is an uninstalled package
           pkgStatus = ectn_NON_INSTALLED;
-          pkgOutVersion = "";
+          pkgOutVersion = QLatin1String("");
         }
       }
-      else if(packageTuple.indexOf("[installed]") != -1)
+      else if(packageTuple.indexOf(QLatin1String("[installed]")) != -1)
       {
         //This is an installed package
         pkgStatus = ectn_FOREIGN;
-        pkgOutVersion = "";
+        pkgOutVersion = QLatin1String("");
       }
-      else if (packageTuple.indexOf("[installed:") != -1)
+      else if (packageTuple.indexOf(QLatin1String("[installed:")) != -1)
       {
-        int i = packageTuple.indexOf(": ");
+        int i = packageTuple.indexOf(QLatin1String(": "));
         pkgOutVersion = packageTuple.mid(i+2);
-        pkgOutVersion = pkgOutVersion.remove("(");
-        pkgOutVersion = pkgOutVersion.remove(")");
-        pkgOutVersion = pkgOutVersion.remove(QRegularExpression("\\].*")).trimmed();
+        pkgOutVersion = pkgOutVersion.remove(QStringLiteral("("));
+        pkgOutVersion = pkgOutVersion.remove(QStringLiteral(")"));
+        pkgOutVersion = pkgOutVersion.remove(QRegularExpression(QStringLiteral("\\].*"))).trimmed();
 
         //Compare actual and new version
         char const * pkgOutVersion_temp = pkgOutVersion.toStdString().c_str();
@@ -936,7 +936,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
         {
           //This is an installed package
           pkgStatus = ectn_FOREIGN;
-          pkgOutVersion = "";
+          pkgOutVersion = QLatin1String("");
         }
 
         //This is an outdated installed package
@@ -950,7 +950,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       {
         //This is an uninstalled package
         pkgStatus = ectn_NON_INSTALLED;
-        pkgOutVersion = "";
+        pkgOutVersion = QLatin1String("");
       }
     }
     else
@@ -959,10 +959,10 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       if (UnixCommand::getLinuxDistro() == ectn_KAOS)
       {        
         pkgDescription = packageTuple;
-        pkgDescription.remove("\t");
+        pkgDescription.remove(QStringLiteral("\t"));
 
         if (pkgDescription.isEmpty())
-          pkgDescription += " ";
+          pkgDescription += QLatin1String(" ");
       }
       else
       {
@@ -970,7 +970,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
           pkgDescription += packageTuple.trimmed();
         else
         {
-          pkgDescription += " ";
+          pkgDescription += QLatin1String(" ");
         }
       }
     }
@@ -1007,12 +1007,12 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
   //QString pkgList = UnixCommand::getAURPackageList(searchString);
   //QStringList packageTuples = pkgList.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
 
-  pkgDescription = "";
+  pkgDescription = QLatin1String("");
   foreach(QString packageTuple, packageTuples)
   {
     if (packageTuple[0].isNumber())
     {
-      int space=packageTuple.indexOf(" ");
+      int space=packageTuple.indexOf(QLatin1String(" "));
       packageTuple = packageTuple.mid(space+1);
     }
 
@@ -1020,7 +1020,7 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
         (UnixCommand::getLinuxDistro() == ectn_KAOS && packageTuple[0] != '\t'))
     {
       //Do we already have a description?
-      if (pkgDescription != "")
+      if (pkgDescription != QLatin1String(""))
       {
         pkgDescription = pkgName + " " + pkgDescription;
 
@@ -1030,13 +1030,13 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
         pld.popularity = pkgVotes;
 
         res->append(pld);
-        pkgDescription = "";
+        pkgDescription = QLatin1String("");
       }
 
       //First we get repository and name!
       QStringList parts = packageTuple.split(' ');
       QString repoName = parts[0];
-      int a = repoName.indexOf("/");
+      int a = repoName.indexOf(QLatin1String("/"));
       pkgRepository = repoName.left(a);
 
       if (pkgRepository != StrConstants::getForeignPkgRepositoryName())
@@ -1049,7 +1049,7 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
       pkgName = repoName.mid(a+1);
       pkgVersion = parts[1];
 
-      QStringList strVotes = parts.filter("(+");
+      QStringList strVotes = parts.filter(QStringLiteral("(+"));
 
       pkgVotes = 0;
       if (strVotes.count() > 0)
@@ -1057,8 +1057,8 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
         if (!strVotes.first().isEmpty())
         {
           //(+65 1.69%)
-          strVotes.first().replace('(', "").replace('+', "");
-          int space = strVotes.first().indexOf(" ");
+          strVotes.first().replace('(', QLatin1String("")).replace('+', QLatin1String(""));
+          int space = strVotes.first().indexOf(QLatin1String(" "));
           strVotes = strVotes.mid(0, space);
           if (!strVotes.isEmpty()) pkgVotes = strVotes.first().toInt();
         }
@@ -1066,28 +1066,28 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
           pkgVotes = 0;
       }
 
-      if(packageTuple.indexOf("(Installed)") != -1)
+      if(packageTuple.indexOf(QLatin1String("(Installed)")) != -1)
       {
         //This is an installed package
         pkgStatus = ectn_FOREIGN;
-        pkgOutVersion = "";
+        pkgOutVersion = QLatin1String("");
       }
-      else if (packageTuple.indexOf("(Installed:") != -1)
+      else if (packageTuple.indexOf(QLatin1String("(Installed:")) != -1)
       {
         //This is an outdated installed package
         pkgStatus = ectn_FOREIGN_OUTDATED;
 
-        int i = packageTuple.indexOf("(Installed:");
+        int i = packageTuple.indexOf(QLatin1String("(Installed:"));
         pkgOutVersion = packageTuple.mid(i+11);
-        pkgOutVersion = pkgOutVersion.remove("(");
-        pkgOutVersion = pkgOutVersion.remove(")");
-        pkgOutVersion = pkgOutVersion.remove(QRegularExpression("\\].*")).trimmed();
+        pkgOutVersion = pkgOutVersion.remove(QStringLiteral("("));
+        pkgOutVersion = pkgOutVersion.remove(QStringLiteral(")"));
+        pkgOutVersion = pkgOutVersion.remove(QRegularExpression(QStringLiteral("\\].*"))).trimmed();
       }
       else
       {
         //This is an uninstalled package
         pkgStatus = ectn_NON_INSTALLED;
-        pkgOutVersion = "";
+        pkgOutVersion = QLatin1String("");
       }
     }
     else
@@ -1099,7 +1099,7 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
           pkgDescription += packageTuple.trimmed();
         else
         {
-          pkgDescription += " ";
+          pkgDescription += QLatin1String(" ");
         }
       }
     }
@@ -1134,26 +1134,26 @@ QString Package::extractFieldFromInfo(const QString &field, const QString &pkgIn
   if (fieldPos > 0)
   {
     int fieldEnd;
-    if(field == "Optional Deps")
+    if(field == QLatin1String("Optional Deps"))
     {
-      fieldPos = pkgInfo.indexOf(":", fieldPos+1);
+      fieldPos = pkgInfo.indexOf(QLatin1String(":"), fieldPos+1);
       fieldPos+=2;
       aux = pkgInfo.mid(fieldPos);
 
-      fieldEnd = aux.indexOf("Conflicts With");
-      int fieldEnd2 = aux.indexOf("Required By");
+      fieldEnd = aux.indexOf(QLatin1String("Conflicts With"));
+      int fieldEnd2 = aux.indexOf(QLatin1String("Required By"));
 
       if(fieldEnd > fieldEnd2 && fieldEnd2 != -1) fieldEnd = fieldEnd2;
 
       aux = aux.left(fieldEnd).trimmed();
-      aux = aux.replace("\n", "<br>");
+      aux = aux.replace(QLatin1String("\n"), QLatin1String("<br>"));
 
-      if (aux.indexOf(":") == -1)
-        aux = aux.replace(" ", "");
+      if (aux.indexOf(QLatin1String(":")) == -1)
+        aux = aux.replace(QLatin1String(" "), QLatin1String(""));
     }
     else
     {
-      fieldPos = pkgInfo.indexOf(":", fieldPos+1);
+      fieldPos = pkgInfo.indexOf(QLatin1String(":"), fieldPos+1);
       fieldPos+=2;
       aux = pkgInfo.mid(fieldPos);
       fieldEnd = aux.indexOf('\n');
@@ -1169,7 +1169,7 @@ QString Package::extractFieldFromInfo(const QString &field, const QString &pkgIn
  */
 QString Package::getName(const QString& pkgInfo)
 {
-  return extractFieldFromInfo("Name", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Name"), pkgInfo);
 }
 
 /*
@@ -1177,7 +1177,7 @@ QString Package::getName(const QString& pkgInfo)
  */
 QString Package::getVersion(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Version", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Version"), pkgInfo);
 }
 
 /*
@@ -1185,7 +1185,7 @@ QString Package::getVersion(const QString &pkgInfo)
  */
 QString Package::getRepository(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Repository", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Repository"), pkgInfo);
 }
 
 /*
@@ -1193,7 +1193,7 @@ QString Package::getRepository(const QString &pkgInfo)
  */
 QString Package::getURL(const QString &pkgInfo)
 {
-  QString URL = extractFieldFromInfo("\nURL", pkgInfo);
+  QString URL = extractFieldFromInfo(QStringLiteral("\nURL"), pkgInfo);
   if (!URL.isEmpty())
     return makeURLClickable(URL);
   else
@@ -1205,7 +1205,7 @@ QString Package::getURL(const QString &pkgInfo)
  */
 QString Package::getLicense(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Licenses", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Licenses"), pkgInfo);
 }
 
 /*
@@ -1213,7 +1213,7 @@ QString Package::getLicense(const QString &pkgInfo)
  */
 QString Package::getGroup(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Groups", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Groups"), pkgInfo);
 }
 
 /*
@@ -1221,7 +1221,7 @@ QString Package::getGroup(const QString &pkgInfo)
  */
 QString Package::getProvides(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Provides", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Provides"), pkgInfo);
 }
 
 /*
@@ -1229,10 +1229,10 @@ QString Package::getProvides(const QString &pkgInfo)
  */
 QString Package::getDependsOn(const QString &pkgInfo)
 {
-  QString res = extractFieldFromInfo("Depends On", pkgInfo);
+  QString res = extractFieldFromInfo(QStringLiteral("Depends On"), pkgInfo);
 
   if (res.isEmpty())
-    res = extractFieldFromInfo("Depends on", pkgInfo);
+    res = extractFieldFromInfo(QStringLiteral("Depends on"), pkgInfo);
 
   return res;
 }
@@ -1242,7 +1242,7 @@ QString Package::getDependsOn(const QString &pkgInfo)
  */
 QString Package::getOptDepends(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Optional Deps", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Optional Deps"), pkgInfo);
 }
 
 /*
@@ -1250,7 +1250,7 @@ QString Package::getOptDepends(const QString &pkgInfo)
  */
 QString Package::getConflictsWith(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Conflicts With", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Conflicts With"), pkgInfo);
 }
 
 /*
@@ -1258,7 +1258,7 @@ QString Package::getConflictsWith(const QString &pkgInfo)
  */
 QString Package::getReplaces(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Replaces", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Replaces"), pkgInfo);
 }
 
 /*
@@ -1266,7 +1266,7 @@ QString Package::getReplaces(const QString &pkgInfo)
  */
 QString Package::getRequiredBy(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Required By", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Required By"), pkgInfo);
 }
 
 /*
@@ -1274,7 +1274,7 @@ QString Package::getRequiredBy(const QString &pkgInfo)
  */
 QString Package::getOptionalFor(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Optional For", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Optional For"), pkgInfo);
 }
 
 /*
@@ -1282,7 +1282,7 @@ QString Package::getOptionalFor(const QString &pkgInfo)
  */
 QString Package::getPackager(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Packager", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Packager"), pkgInfo);
 }
 
 /*
@@ -1290,7 +1290,7 @@ QString Package::getPackager(const QString &pkgInfo)
  */
 QString Package::getArch(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Architecture", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Architecture"), pkgInfo);
 }
 
 /*
@@ -1298,7 +1298,7 @@ QString Package::getArch(const QString &pkgInfo)
  */
 QDateTime Package::getBuildDate(const QString &pkgInfo)
 {
-  QString aux = extractFieldFromInfo("Build Date", pkgInfo);
+  QString aux = extractFieldFromInfo(QStringLiteral("Build Date"), pkgInfo);
   return QDateTime::fromString(aux); //"ddd MMM d hh:mm:ss yyyy");
 }
 
@@ -1307,12 +1307,12 @@ QDateTime Package::getBuildDate(const QString &pkgInfo)
  */
 double Package::getDownloadSize(const QString &pkgInfo)
 {
-  QString aux = extractFieldFromInfo("Download Size", pkgInfo);
-  bool isKByte = (aux.indexOf("KiB", Qt::CaseInsensitive) != -1);
-  bool isMega = (aux.indexOf("MiB", Qt::CaseInsensitive) != -1);
+  QString aux = extractFieldFromInfo(QStringLiteral("Download Size"), pkgInfo);
+  bool isKByte = (aux.indexOf(QLatin1String("KiB"), Qt::CaseInsensitive) != -1);
+  bool isMega = (aux.indexOf(QLatin1String("MiB"), Qt::CaseInsensitive) != -1);
   //bool isByte = (aux.indexOf(" B", Qt::CaseInsensitive) != -1);
 
-  aux = aux.section(QRegularExpression("\\s"), 0, 0);
+  aux = aux.section(QRegularExpression(QStringLiteral("\\s")), 0, 0);
 
   bool ok;
   double res = aux.toDouble(&ok);
@@ -1337,7 +1337,7 @@ double Package::getDownloadSize(const QString &pkgInfo)
  */
 QString Package::getDownloadSizeAsString(const QString &pkgInfo)
 {
-  QString aux = extractFieldFromInfo("Download Size", pkgInfo);
+  QString aux = extractFieldFromInfo(QStringLiteral("Download Size"), pkgInfo);
   return aux;
 }
 
@@ -1346,11 +1346,11 @@ QString Package::getDownloadSizeAsString(const QString &pkgInfo)
  */
 double Package::getInstalledSize(const QString &pkgInfo)
 {
-  QString aux = extractFieldFromInfo("Installed Size", pkgInfo);
-  bool isKByte = (aux.indexOf("KiB", Qt::CaseInsensitive) != -1);
-  bool isMega = (aux.indexOf("MiB", Qt::CaseInsensitive) != -1);
+  QString aux = extractFieldFromInfo(QStringLiteral("Installed Size"), pkgInfo);
+  bool isKByte = (aux.indexOf(QLatin1String("KiB"), Qt::CaseInsensitive) != -1);
+  bool isMega = (aux.indexOf(QLatin1String("MiB"), Qt::CaseInsensitive) != -1);
 
-  aux = aux.section(QRegularExpression("\\s"), 0, 0);
+  aux = aux.section(QRegularExpression(QStringLiteral("\\s")), 0, 0);
 
   bool ok;
   double res = aux.toDouble(&ok);
@@ -1375,7 +1375,7 @@ double Package::getInstalledSize(const QString &pkgInfo)
  */
 QString Package::getInstallReason(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Install Reason", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Install Reason"), pkgInfo);
 }
 
 /*
@@ -1383,7 +1383,7 @@ QString Package::getInstallReason(const QString &pkgInfo)
  */
 QString Package::getInstalledSizeAsString(const QString &pkgInfo)
 {
-  QString aux = extractFieldFromInfo("Installed Size", pkgInfo);
+  QString aux = extractFieldFromInfo(QStringLiteral("Installed Size"), pkgInfo);
   return aux;
 }
 
@@ -1636,7 +1636,7 @@ int Package::alpm_pkg_vercmp(const char *a, const char *b)
  */
 QString Package::getDescription(const QString &pkgInfo)
 {
-  return extractFieldFromInfo("Description", pkgInfo);
+  return extractFieldFromInfo(QStringLiteral("Description"), pkgInfo);
 }
 
 /*
@@ -1648,21 +1648,21 @@ PackageInfoData Package::getKCPInformation(const QString &pkgName)
   QString pkgInfo = UnixCommand::getKCPPackageInformation(pkgName);
   pkgInfo.remove("\033[0;1m");
   pkgInfo.remove("\033[0m");
-  pkgInfo.remove("[1;33m");
-  pkgInfo.remove("[00;31m");
+  pkgInfo.remove(QStringLiteral("[1;33m"));
+  pkgInfo.remove(QStringLiteral("[00;31m"));
   pkgInfo.remove("\033[1;34m");
   pkgInfo.remove("\033[0;1m");
-  pkgInfo.remove("c");
-  pkgInfo.remove("C");
-  pkgInfo.remove("");
-  pkgInfo.remove("[m[0;37m");
-  pkgInfo.remove("o");
-  pkgInfo.remove("[m");
-  pkgInfo.remove(";37m");
-  pkgInfo.remove("[c");
-  pkgInfo.remove("[mo");
-  pkgInfo.remove("[1m");
-  pkgInfo.remove("[m");
+  pkgInfo.remove(QStringLiteral("c"));
+  pkgInfo.remove(QStringLiteral("C"));
+  pkgInfo.remove(QStringLiteral(""));
+  pkgInfo.remove(QStringLiteral("[m[0;37m"));
+  pkgInfo.remove(QStringLiteral("o"));
+  pkgInfo.remove(QStringLiteral("[m"));
+  pkgInfo.remove(QStringLiteral(";37m"));
+  pkgInfo.remove(QStringLiteral("[c"));
+  pkgInfo.remove(QStringLiteral("[mo"));
+  pkgInfo.remove(QStringLiteral("[1m"));
+  pkgInfo.remove(QStringLiteral("[m"));
 
   res.url = getURL(pkgInfo);
   res.license = getLicense(pkgInfo);
@@ -1759,7 +1759,7 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
   QString res = removeColorCodesFromStr(UnixCommand::getOutdatedAURPackageList());
   res = res.trimmed();
 
-  QStringList listOfPkgs = res.split("\n", QString::SkipEmptyParts);
+  QStringList listOfPkgs = res.split(QStringLiteral("\n"), QString::SkipEmptyParts);
   QStringList ignorePkgList = UnixCommand::getIgnorePkgsFromPacmanConf();
 
   if ((getForeignRepositoryToolName() == ctn_YAOURT_TOOL) ||
@@ -1773,7 +1773,7 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
       if (line.contains(StrConstants::getForeignRepositoryTargetPrefix(), Qt::CaseInsensitive))
       {
         line = line.remove(StrConstants::getForeignRepositoryTargetPrefix());
-        QStringList nameVersion = line.split(" ", QString::SkipEmptyParts);
+        QStringList nameVersion = line.split(QStringLiteral(" "), QString::SkipEmptyParts);
         QString pkgName = nameVersion.at(0);
 
         if (getForeignRepositoryToolName() == ctn_KCP_TOOL)
@@ -1798,10 +1798,10 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
       }
       else //We have TRIZEN output here
       {
-        QStringList nameVersion = line.split(" ", QString::SkipEmptyParts);
+        QStringList nameVersion = line.split(QStringLiteral(" "), QString::SkipEmptyParts);
         QString pkgName = nameVersion.at(0);
 
-        if (pkgName=="::") continue;
+        if (pkgName==QLatin1String("::")) continue;
 
         if (!ignorePkgList.contains(pkgName))
         {
@@ -1817,7 +1817,7 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
   {
     foreach (QString line, listOfPkgs)
     {
-      QStringList sl = line.split(" ", QString::SkipEmptyParts);
+      QStringList sl = line.split(QStringLiteral(" "), QString::SkipEmptyParts);
 
       if (sl[1] != StrConstants::getForeignPkgRepositoryName())
         continue;
@@ -1854,15 +1854,15 @@ QStringList Package::getContents(const QString& pkgName, bool isInstalled)
   }
 
   QString aux(result);
-  QStringList rsl = aux.split("\n", QString::SkipEmptyParts);
+  QStringList rsl = aux.split(QStringLiteral("\n"), QString::SkipEmptyParts);
 
   if ( !rsl.isEmpty() ){
-    if (rsl.at(0) == "./"){
+    if (rsl.at(0) == QLatin1String("./")){
       rsl.removeFirst();
     }
     if (isInstalled)
     {
-      rsl.replaceInStrings(QRegularExpression(pkgName + " "), "");
+      rsl.replaceInStrings(QRegularExpression(pkgName + " "), QLatin1String(""));
       rsl.sort();
       slResult = rsl;
     }
@@ -1873,7 +1873,7 @@ QStringList Package::getContents(const QString& pkgName, bool isInstalled)
       QStringList rsl2;
       foreach(QString line, rsl)
       {
-        QStringList slAux = line.split("\t", QString::SkipEmptyParts);
+        QStringList slAux = line.split(QStringLiteral("\t"), QString::SkipEmptyParts);
         rsl2.append(QString(slAux.at(1).trimmed()));
       }
 
@@ -1892,8 +1892,8 @@ QStringList Package::getOptionalDeps(const QString &pkgName)
 {
   QString pkgInfo = UnixCommand::getPackageInformation(pkgName, false);
   QString aux = Package::getOptDepends(pkgInfo);
-  QStringList result = aux.split("<br>", QString::SkipEmptyParts);
-  result.removeAll("None");
+  QStringList result = aux.split(QStringLiteral("<br>"), QString::SkipEmptyParts);
+  result.removeAll(QStringLiteral("None"));
 
   return result;
 }
@@ -1903,32 +1903,32 @@ QStringList Package::getOptionalDeps(const QString &pkgName)
  */
 QString Package::parseSearchString(QString searchStr, bool exactMatch)
 {
-  if (searchStr.indexOf("*.") == 0){
+  if (searchStr.indexOf(QLatin1String("*.")) == 0){
     searchStr = searchStr.remove(0, 2);
     searchStr.insert(0, "\\S+\\.");
   }
 
-  if (searchStr.indexOf("*") == 0){
+  if (searchStr.indexOf(QLatin1String("*")) == 0){
     searchStr = searchStr.remove(0, 1);
     searchStr.insert(0, "\\S+");
   }
 
-  if (searchStr.endsWith("*")){
+  if (searchStr.endsWith(QLatin1String("*"))){
     searchStr.remove(searchStr.length()-1, 1);
     searchStr.append("\\S*");
   }
 
-  if (searchStr.indexOf("^") == -1 && searchStr.indexOf("\\S") != 0){
+  if (searchStr.indexOf(QLatin1String("^")) == -1 && searchStr.indexOf(QLatin1String("\\S")) != 0){
     if (!exactMatch) searchStr.insert(0, "\\S*");
     else searchStr.insert(0, "^");
   }
 
-  if (searchStr.indexOf("$") == -1){
-    if (!exactMatch && !searchStr.endsWith("\\S*")) searchStr.append("\\S*");
+  if (searchStr.indexOf(QLatin1String("$")) == -1){
+    if (!exactMatch && !searchStr.endsWith(QLatin1String("\\S*"))) searchStr.append("\\S*");
     else searchStr.append("$");
   }
 
-  searchStr.replace("?", ".");
+  searchStr.replace(QLatin1String("?"), QLatin1String("."));
   return searchStr;
 }
 
@@ -1958,9 +1958,9 @@ QString Package::getForeignRepositoryToolNameParam()
   static QString ret;
 
   if( UnixCommand::getLinuxDistro() == ectn_CHAKRA )
-    ret = QLatin1String( "chaser" );
+    ret = QStringLiteral( "chaser" );
   else if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-    ret = QLatin1String( "kcp" );
+    ret = QStringLiteral( "kcp" );
   else // We are talking about ARCH based distros...
     ret = SettingsManager::getAURTool();
 
@@ -1975,9 +1975,9 @@ QString Package::getForeignRepositoryToolName()
   static QString ret;
 
   if( UnixCommand::getLinuxDistro() == ectn_CHAKRA )
-    ret = QLatin1String( "chaser" );
+    ret = QStringLiteral( "chaser" );
   else if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-    ret = QLatin1String( "kcp" );
+    ret = QStringLiteral( "kcp" );
   else // We are talking about ARCH based distros...
     ret = SettingsManager::getAURToolName();
 

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -46,7 +46,7 @@ QString Package::getBaseName( const QString& p )
 {
 	QString packageBaseName=QLatin1String("");
 	QString aux(p);
-	int numberOfSegments = p.count('-')+1;
+    int numberOfSegments = p.count(QLatin1Char('-'))+1;
 	int nameSegment = numberOfSegments-3;
 
 	for (int i=1; i<= nameSegment; i++){
@@ -67,7 +67,7 @@ QString Package::getBaseName( const QString& p )
 QString Package::makeURLClickable( const QString &s )
 {
   QString sb = s;
-  QRegExp rx("((ht|f)tp(s?))://(\\S)+[^\"|)|(|.|\\s|\\n]");
+  QRegExp rx(QStringLiteral("((ht|f)tp(s?))://(\\S)+[^\"|)|(|.|\\s|\\n]"));
   //QRegExp rx1("^|[\\s]+(www\\.)(\\S)+[^\"|)|(|.|\\s|\\n]");
   rx.setCaseSensitivity( Qt::CaseInsensitive );
   //rx1.setCaseSensitivity( Qt::CaseInsensitive );
@@ -79,7 +79,7 @@ QString Package::makeURLClickable( const QString &s )
 		QString s1 = rx.cap();
     QString ns;
 
-    ns = "<a href=\"" + s1 + "\">" + s1 + "</a>";
+    ns = QLatin1String("<a href=\"") + s1 + QLatin1String("\">") + s1 + QLatin1String("</a>");
     sb.replace( ini, s1.length(), ns);
 		search = ini + (2*s1.length()) + 15;	
 	}
@@ -160,13 +160,13 @@ QString Package::makeAnchorOfOptionalDep(const QString &optionalDeps)
     {
       name = dep.left(colon).trimmed();
 
-      newDep = "<a href=\"goto:" + name + "\">" + name + "</a> " + dep.right(dep.length()-colon);
-      newDeps += newDep + "<br>";
+      newDep = QLatin1String("<a href=\"goto:") + name + QLatin1String("\">") + name + QLatin1String("</a> ") + dep.right(dep.length()-colon);
+      newDeps += newDep + QLatin1String("<br>");
     }
     else
     {
-      newDep = "<a href=\"goto:" + dep + "\">" + dep + "</a> ";
-      newDeps += newDep + "<br>";
+      newDep = QLatin1String("<a href=\"goto:") + dep + QLatin1String("\">") + dep + QLatin1String("</a> ");
+      newDeps += newDep + QLatin1String("<br>");
     }
   }
 
@@ -189,7 +189,7 @@ QString Package::makeAnchorOfPackage(const QString &packages)
         !dep.contains(QLatin1String("<")) &&
         !dep.contains(QLatin1String(">")))
     {
-      newDeps += "<a href=\"goto:" + dep + "\">" + dep + "</a> ";
+      newDeps += QLatin1String("<a href=\"goto:") + dep + QLatin1String("\">") + dep + QLatin1String("</a> ");
     }
     else
     {
@@ -228,7 +228,7 @@ QString Package::makeAnchorOfPackage(const QString &packages)
         newDep = dep.left(p);
       }
 
-      newDeps += "<a href=\"goto:" + newDep + "\">" + dep + "</a> ";
+      newDeps += QLatin1String("<a href=\"goto:") + newDep + QLatin1String("\">") + dep + QLatin1String("</a> ");
     }
   }
 
@@ -246,12 +246,12 @@ QSet<QString>* Package::getUnrequiredPackageList()
 
   if (SettingsManager::hasPacmanBackend())
   {
-    QString unrequiredPkgList = UnixCommand::getUnrequiredPackageList();
+    QString unrequiredPkgList = QString::fromUtf8(UnixCommand::getUnrequiredPackageList());
     QStringList packageTuples = unrequiredPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
     foreach(QString packageTuple, packageTuples)
     {
-      QStringList parts = packageTuple.split(' ');
+      QStringList parts = packageTuple.split(QLatin1Char(' '));
       {
         res->insert(parts[0]); //We only need the package name!
       }
@@ -281,13 +281,13 @@ QStringList *Package::getOutdatedStringList()
 
   if (SettingsManager::hasPacmanBackend())
   {
-    QString outPkgList = UnixCommand::getOutdatedPackageList();
+    QString outPkgList = QString::fromUtf8(UnixCommand::getOutdatedPackageList());
     QStringList packageTuples = outPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
     QStringList ignorePkgList = UnixCommand::getIgnorePkgsFromPacmanConf();
 
     foreach(QString packageTuple, packageTuples)
     {
-      QStringList parts = packageTuple.split(' ');
+      QStringList parts = packageTuple.split(QLatin1Char(' '));
       {
         QString pkgName;
         pkgName = parts[0];
@@ -326,7 +326,7 @@ QString Package::removeColorCodesFromStr(const QString &str)
 {
   QString ret = str;
 
-  ret = ret.remove("\033");
+  ret = ret.remove(QStringLiteral("\033"));
   ret = ret.remove(QStringLiteral("[1;31m"));
   ret = ret.remove(QStringLiteral("[1;32m"));
   ret = ret.remove(QStringLiteral("[1;33m"));
@@ -337,7 +337,7 @@ QString Package::removeColorCodesFromStr(const QString &str)
   ret = ret.remove(QStringLiteral("[m"));
   ret = ret.remove(QStringLiteral("[0m"));
   ret = ret.remove(QStringLiteral("[1m"));
-  ret = ret.remove("\u001B");
+  ret = ret.remove(QStringLiteral("\u001B"));
 
   return ret;
 }
@@ -358,7 +358,7 @@ QStringList *Package::getOutdatedAURStringList()
       getForeignRepositoryToolName() != ctn_KCP_TOOL)
     return res;
 
-  QString outPkgList = removeColorCodesFromStr(UnixCommand::getOutdatedAURPackageList());
+  QString outPkgList = removeColorCodesFromStr(QString::fromUtf8(UnixCommand::getOutdatedAURPackageList()));
   outPkgList = outPkgList.trimmed();
 
   QStringList packageTuples = outPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
@@ -366,7 +366,7 @@ QStringList *Package::getOutdatedAURStringList()
 
   foreach(QString packageTuple, packageTuples)
   {
-    QStringList parts = packageTuple.split(' ', QString::SkipEmptyParts);
+    QStringList parts = packageTuple.split(QLatin1Char(' '), QString::SkipEmptyParts);
     {
       if (getForeignRepositoryToolName() == ctn_YAOURT_TOOL ||
           getForeignRepositoryToolName() == ctn_TRIZEN_TOOL ||
@@ -429,7 +429,7 @@ QStringList *Package::getOutdatedAURStringList()
  */
 QStringList *Package::getPackageGroups()
 {
-  QString packagesFromGroup = UnixCommand::getPackageGroups();
+  QString packagesFromGroup = QString::fromUtf8(UnixCommand::getPackageGroups());
   QStringList packageTuples = packagesFromGroup.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList * res = new QStringList();
 
@@ -452,13 +452,13 @@ QStringList *Package::getPackageGroups()
  */
 QStringList *Package::getPackagesOfGroup(const QString &groupName)
 {
-  QString packagesFromGroup = UnixCommand::getPackagesFromGroup(groupName);
+  QString packagesFromGroup = QString::fromUtf8(UnixCommand::getPackagesFromGroup(groupName));
   QStringList packageTuples = packagesFromGroup.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList * res = new QStringList();
 
   foreach(QString packageTuple, packageTuples)
   {
-    QStringList parts = packageTuple.split(' ');
+    QStringList parts = packageTuple.split(QLatin1Char(' '));
     res->append(parts[1]); //We only need the package name!
   }
 
@@ -471,7 +471,7 @@ QStringList *Package::getPackagesOfGroup(const QString &groupName)
  */
 QList<PackageListData> *Package::getTargetUpgradeList(const QString &pkgName)
 {
-  QString targets = UnixCommand::getTargetUpgradeList(pkgName);
+  QString targets = QString::fromUtf8(UnixCommand::getTargetUpgradeList(pkgName));
   QStringList packageTuples = targets.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QList<PackageListData> *res = new QList<PackageListData>();
   packageTuples.sort();
@@ -492,7 +492,7 @@ QList<PackageListData> *Package::getTargetUpgradeList(const QString &pkgName)
     }
     else if (data.count() == 1)
     {
-      ld = PackageListData(data.at(0), QLatin1String(""), 0);
+      ld = PackageListData(data.at(0), QLatin1String(""), QStringLiteral("0"));
     }
 
     res->append(ld);
@@ -506,7 +506,7 @@ QList<PackageListData> *Package::getTargetUpgradeList(const QString &pkgName)
  */
 QStringList *Package::getTargetRemovalList(const QString &pkgName, const QString &removeCommand)
 {
-  QString targets = UnixCommand::getTargetRemovalList(pkgName, removeCommand);
+  QString targets = QString::fromUtf8(UnixCommand::getTargetRemovalList(pkgName, removeCommand));
   QStringList packageTuples = targets.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
   QStringList * res = new QStringList();
 
@@ -528,15 +528,15 @@ QList<PackageListData> *Package::getForeignPackageList()
 
   if (SettingsManager::hasPacmanBackend())
   {
-    QString foreignPkgList = UnixCommand::getForeignPackageList();
+    QString foreignPkgList = QString::fromUtf8(UnixCommand::getForeignPackageList());
     QStringList packageTuples = foreignPkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
     foreach(QString packageTuple, packageTuples)
     {
-      QStringList parts = packageTuple.split(' ');
+      QStringList parts = packageTuple.split(QLatin1Char(' '));
       if (parts.size() == 2)
       {
-        QString desc=parts[0] + " " + Package::getInformationDescription(parts[0], true);
+        QString desc=parts[0] + QLatin1String(" ") + Package::getInformationDescription(parts[0], true);
         res->append(PackageListData(parts[0], QLatin1String(""), parts[1], desc, ectn_FOREIGN));
       }
     }
@@ -548,8 +548,8 @@ QList<PackageListData> *Package::getForeignPackageList()
 
     foreach(QString packageTuple, packageTuples)
     {
-      QStringList parts = packageTuple.split("<o'o>");
-      res->append(PackageListData(parts[0], "", parts[1], parts[0] + " " + parts[2], ectn_FOREIGN));
+      QStringList parts = packageTuple.split(QStringLiteral("<o'o>"));
+      res->append(PackageListData(parts[0], QLatin1String(""), parts[1], parts[0] + QLatin1Char(' ') + parts[2], ectn_FOREIGN));
     }
   }
 #endif
@@ -572,7 +572,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
   {
     QString pkgName, pkgRepository, pkgVersion, pkgDescription, pkgOutVersion;
     PackageStatus pkgStatus;
-    QString pkgList = UnixCommand::getPackageList(packageName);
+    QString pkgList = QString::fromUtf8(UnixCommand::getPackageList(packageName));
     QStringList packageTuples = pkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
     if(!pkgList.isEmpty())
@@ -585,7 +585,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
           //Do we already have a description?
           if (pkgDescription != QLatin1String(""))
           {
-            pkgDescription = pkgName + " " + pkgDescription;
+            pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
 
             PackageListData pld =
                 PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgOutVersion);
@@ -599,7 +599,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
           }
 
           //First we get repository and name!
-          QStringList parts = packageTuple.split(' ');
+          QStringList parts = packageTuple.split(QLatin1Char(' '));
           QString repoName = parts[0];
           int a = repoName.indexOf(QLatin1String("/"));
           pkgRepository = repoName.left(a);
@@ -619,7 +619,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
 
             int i = packageTuple.indexOf(QLatin1String("[installed:"));
             pkgOutVersion = packageTuple.mid(i+11);
-            pkgOutVersion = pkgOutVersion.remove(']').trimmed();
+            pkgOutVersion = pkgOutVersion.remove(QLatin1Char(']')).trimmed();
           }
           else
           {
@@ -639,7 +639,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
       }
 
       //And adds the very last package...
-      pkgDescription = pkgName + " " + pkgDescription;
+      pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
       PackageListData pld =
           PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgOutVersion);
 
@@ -659,39 +659,39 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
     bool ok;
     bool hasOutdatedPackages = checkUpdatesOutdatedPackages->count() > 0;
 
-    pkgDescription = "";
+    pkgDescription = QLatin1String("");
     foreach(QString packageTuple, pkgList)
     {
       if (!packageTuple[0].isSpace())
       {
         //Do we already have a description?
-        if (pkgDescription != "")
+        if (pkgDescription != QLatin1String(""))
         {
-          pkgDescription = pkgName + " " + pkgDescription;
+          pkgDescription = pkgName + QLatin1Char(' ') + pkgDescription;
 
           PackageListData pld =
               PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription,
                               pkgStatus, pkgDownSize, pkgOutVersion);
 
           res->append(pld);
-          pkgDescription = "";
+          pkgDescription = QLatin1String("");
         }
 
         //First we get repository and name!
-        QStringList parts = packageTuple.split(' ');
+        QStringList parts = packageTuple.split(QLatin1Char(' '));
         pkgRepository = parts[1];
         pkgName = parts[2];
         pkgVersion = parts[3];
         pkgSize = parts[5];
         pkgDownSize = pkgSize.toLong(&ok);
 
-        if(parts[0] == "i")
+        if(parts[0] == QLatin1Char('i'))
         {
           //This is an installed package
           if (!hasOutdatedPackages)
           {
             pkgStatus = ectn_INSTALLED;
-            pkgOutVersion = "";
+            pkgOutVersion = QLatin1String("");
           }
           else
           {
@@ -699,7 +699,7 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
             if (newVersion.isEmpty())
             {
               pkgStatus = ectn_INSTALLED;
-              pkgOutVersion = "";
+              pkgOutVersion = QLatin1String("");
             }
             else
             {
@@ -709,17 +709,17 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
             }
           }
         }
-        else if (parts[0] == "o")
+        else if (parts[0] == QLatin1String("o"))
         {
           //This is an outdated installed package
           pkgStatus = ectn_OUTDATED;
           pkgOutVersion = parts[4];
         }
-        else if (parts[0] == "n")
+        else if (parts[0] == QLatin1Char('n'))
         {
           //This is an uninstalled package
           pkgStatus = ectn_NON_INSTALLED;
-          pkgOutVersion = "";
+          pkgOutVersion = QLatin1String("");
         }
       }
       else
@@ -728,12 +728,12 @@ QList<PackageListData> * Package::getPackageList(const QString &packageName, con
         if (!packageTuple.trimmed().isEmpty())
           pkgDescription += packageTuple.trimmed();
         else
-          pkgDescription += " ";
+          pkgDescription += QLatin1Char(' ');
       }
     }
 
     //And adds the very last package...
-    pkgDescription = pkgName + " " + pkgDescription;
+    pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
     PackageListData pld =
         PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgDownSize, pkgOutVersion);
 
@@ -753,7 +753,7 @@ QString Package::getAURUrl(const QString &pkgName)
 
   if (getForeignRepositoryToolName() != ctn_KCP_TOOL)
   {
-    QString pkgInfo = UnixCommand::getAURUrl(pkgName);
+    QString pkgInfo = QString::fromUtf8(UnixCommand::getAURUrl(pkgName));
     url = getURL(pkgInfo);
   }
 
@@ -779,7 +779,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
     return res;
 
   QString aurTool = getForeignRepositoryToolName();
-  QString pkgList = UnixCommand::getAURPackageList(searchString);
+  QString pkgList = QString::fromUtf8(UnixCommand::getAURPackageList(searchString));
   QStringList packageTuples = pkgList.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
   if (aurTool == ctn_YAY_TOOL)
@@ -797,12 +797,12 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
     }
 
     if ((UnixCommand::getLinuxDistro() != ectn_KAOS && !packageTuple[0].isSpace()) ||
-        (UnixCommand::getLinuxDistro() == ectn_KAOS && packageTuple[0] != '\t'))
+        (UnixCommand::getLinuxDistro() == ectn_KAOS && packageTuple[0] != QLatin1Char('\t')))
     {
       //Do we already have a description?
       if (pkgDescription != QLatin1String(""))
       {
-        pkgDescription = pkgName + " " + pkgDescription;
+        pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
 
         PackageListData pld =
             PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgOutVersion);
@@ -814,7 +814,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       }
 
       //First we get repository and name!
-      QStringList parts = packageTuple.split(' ');
+      QStringList parts = packageTuple.split(QLatin1Char(' '));
 
       if (UnixCommand::getLinuxDistro() == ectn_KAOS)
       {
@@ -847,14 +847,14 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
       if (aurTool == ctn_TRIZEN_TOOL)
       {
         if (!strVotes.first().isEmpty())
-          pkgVotes = strVotes.first().replace('[', QLatin1String("")).replace(']', QLatin1String("")).replace('+', QLatin1String("")).toInt();
+          pkgVotes = strVotes.first().replace(QLatin1Char('['), QLatin1String("")).replace(QLatin1Char(']'), QLatin1String("")).replace(QLatin1Char('+'), QLatin1String("")).toInt();
         else
           pkgVotes = 0;
       }
       else if (aurTool != ctn_CHASER_TOOL && aurTool != ctn_PACAUR_TOOL && aurTool != ctn_PIKAUR_TOOL && strVotes.count() > 0)
       {
         if (!strVotes.first().isEmpty())
-          pkgVotes = strVotes.first().replace('(', QLatin1String("")).replace(')', QLatin1String("")).toInt();
+          pkgVotes = strVotes.first().replace(QLatin1Char('('), QLatin1String("")).replace(QLatin1Char(')'), QLatin1String("")).toInt();
         else
           pkgVotes = 0;
       }
@@ -979,7 +979,7 @@ QList<PackageListData> * Package::getAURPackageList(const QString& searchString)
   //And adds the very last package...
   if (packageTuples.count() > 1)
   {
-    pkgDescription = pkgName + " " + pkgDescription;
+    pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
     PackageListData pld =
         PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgOutVersion);
     pld.popularity = pkgVotes;
@@ -1017,12 +1017,12 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
     }
 
     if ((UnixCommand::getLinuxDistro() != ectn_KAOS && !packageTuple[0].isSpace()) ||
-        (UnixCommand::getLinuxDistro() == ectn_KAOS && packageTuple[0] != '\t'))
+        (UnixCommand::getLinuxDistro() == ectn_KAOS && packageTuple[0] != QLatin1Char('\t')))
     {
       //Do we already have a description?
       if (pkgDescription != QLatin1String(""))
       {
-        pkgDescription = pkgName + " " + pkgDescription;
+        pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
 
         PackageListData pld =
             PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgOutVersion);
@@ -1034,7 +1034,7 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
       }
 
       //First we get repository and name!
-      QStringList parts = packageTuple.split(' ');
+      QStringList parts = packageTuple.split(QLatin1Char(' '));
       QString repoName = parts[0];
       int a = repoName.indexOf(QLatin1String("/"));
       pkgRepository = repoName.left(a);
@@ -1057,7 +1057,7 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
         if (!strVotes.first().isEmpty())
         {
           //(+65 1.69%)
-          strVotes.first().replace('(', QLatin1String("")).replace('+', QLatin1String(""));
+          strVotes.first().replace(QLatin1Char('('), QLatin1String("")).replace(QLatin1Char('+'), QLatin1String(""));
           int space = strVotes.first().indexOf(QLatin1String(" "));
           strVotes = strVotes.mid(0, space);
           if (!strVotes.isEmpty()) pkgVotes = strVotes.first().toInt();
@@ -1108,7 +1108,7 @@ QList<PackageListData> *Package::getYayPackageList(const QStringList &packageTup
   //And adds the very last package...
   if (packageTuples.count() > 1)
   {
-    pkgDescription = pkgName + " " + pkgDescription;
+    pkgDescription = pkgName + QLatin1String(" ") + pkgDescription;
     PackageListData pld =
         PackageListData(pkgName, pkgRepository, pkgVersion, pkgDescription, pkgStatus, pkgOutVersion);
     pld.popularity = pkgVotes;
@@ -1156,7 +1156,7 @@ QString Package::extractFieldFromInfo(const QString &field, const QString &pkgIn
       fieldPos = pkgInfo.indexOf(QLatin1String(":"), fieldPos+1);
       fieldPos+=2;
       aux = pkgInfo.mid(fieldPos);
-      fieldEnd = aux.indexOf('\n');
+      fieldEnd = aux.indexOf(QLatin1Char('\n'));
       aux = aux.left(fieldEnd).trimmed();
     }
   }
@@ -1645,13 +1645,13 @@ QString Package::getDescription(const QString &pkgInfo)
 PackageInfoData Package::getKCPInformation(const QString &pkgName)
 {
   PackageInfoData res;
-  QString pkgInfo = UnixCommand::getKCPPackageInformation(pkgName);
-  pkgInfo.remove("\033[0;1m");
-  pkgInfo.remove("\033[0m");
+  QString pkgInfo = QString::fromUtf8(UnixCommand::getKCPPackageInformation(pkgName));
+  pkgInfo.remove(QStringLiteral("\033[0;1m"));
+  pkgInfo.remove(QStringLiteral("\033[0m"));
   pkgInfo.remove(QStringLiteral("[1;33m"));
   pkgInfo.remove(QStringLiteral("[00;31m"));
-  pkgInfo.remove("\033[1;34m");
-  pkgInfo.remove("\033[0;1m");
+  pkgInfo.remove(QStringLiteral("\033[1;34m"));
+  pkgInfo.remove(QStringLiteral("\033[0;1m"));
   pkgInfo.remove(QStringLiteral("c"));
   pkgInfo.remove(QStringLiteral("C"));
   pkgInfo.remove(QStringLiteral(""));
@@ -1684,7 +1684,7 @@ PackageInfoData Package::getInformation(const QString &pkgName, bool foreignPack
   PackageInfoData res;
   //res = AlpmBackend::getPackageInfo(pkgName, foreignPackage);
 
-  QString pkgInfo = UnixCommand::getPackageInformation(pkgName, foreignPackage);
+  QString pkgInfo = QString::fromUtf8(UnixCommand::getPackageInformation(pkgName, foreignPackage));
 
   res.name = pkgName;
   res.version = getVersion(pkgInfo);
@@ -1716,7 +1716,7 @@ PackageInfoData Package::getInformation(const QString &pkgName, bool foreignPack
  */
 double Package::getDownloadSizeDescription(const QString &pkgName)
 {
-  QString pkgInfo = UnixCommand::getPackageInformation(pkgName, false);
+  QString pkgInfo = QString::fromUtf8(UnixCommand::getPackageInformation(pkgName, false));
   return getDownloadSize(pkgInfo);
 }
 
@@ -1725,7 +1725,7 @@ double Package::getDownloadSizeDescription(const QString &pkgName)
  */
 QString Package::getInformationDescription(const QString &pkgName, bool foreignPackage)
 {
-  QString pkgInfo = UnixCommand::getPackageInformation(pkgName, foreignPackage);
+  QString pkgInfo = QString::fromUtf8(UnixCommand::getPackageInformation(pkgName, foreignPackage));
   return getDescription(pkgInfo);
 }
 
@@ -1734,7 +1734,7 @@ QString Package::getInformationDescription(const QString &pkgName, bool foreignP
  */
 QString Package::getInformationInstalledSize(const QString &pkgName, bool foreignPackage)
 {
-  QString pkgInfo = UnixCommand::getPackageInformation(pkgName, foreignPackage);
+  QString pkgInfo = QString::fromUtf8(UnixCommand::getPackageInformation(pkgName, foreignPackage));
   return kbytesToSize(getInstalledSize(pkgInfo));
 }
 
@@ -1756,7 +1756,7 @@ QHash<QString, QString> Package::getAUROutdatedPackagesNameVersion()
     return hash;
   }
 
-  QString res = removeColorCodesFromStr(UnixCommand::getOutdatedAURPackageList());
+  QString res = removeColorCodesFromStr(QString::fromUtf8(UnixCommand::getOutdatedAURPackageList()));
   res = res.trimmed();
 
   QStringList listOfPkgs = res.split(QStringLiteral("\n"), QString::SkipEmptyParts);
@@ -1853,7 +1853,7 @@ QStringList Package::getContents(const QString& pkgName, bool isInstalled)
     result = UnixCommand::getPackageContentsUsingPkgfile(pkgName);
   }
 
-  QString aux(result);
+  QString aux(QString::fromUtf8(result));
   QStringList rsl = aux.split(QStringLiteral("\n"), QString::SkipEmptyParts);
 
   if ( !rsl.isEmpty() ){
@@ -1862,7 +1862,7 @@ QStringList Package::getContents(const QString& pkgName, bool isInstalled)
     }
     if (isInstalled)
     {
-      rsl.replaceInStrings(QRegularExpression(pkgName + " "), QLatin1String(""));
+      rsl.replaceInStrings(QRegularExpression(pkgName + QLatin1Char(' ')), QLatin1String(""));
       rsl.sort();
       slResult = rsl;
     }
@@ -1890,7 +1890,7 @@ QStringList Package::getContents(const QString& pkgName, bool isInstalled)
  */
 QStringList Package::getOptionalDeps(const QString &pkgName)
 {
-  QString pkgInfo = UnixCommand::getPackageInformation(pkgName, false);
+  QString pkgInfo = QString::fromUtf8(UnixCommand::getPackageInformation(pkgName, false));
   QString aux = Package::getOptDepends(pkgInfo);
   QStringList result = aux.split(QStringLiteral("<br>"), QString::SkipEmptyParts);
   result.removeAll(QStringLiteral("None"));
@@ -1905,27 +1905,27 @@ QString Package::parseSearchString(QString searchStr, bool exactMatch)
 {
   if (searchStr.indexOf(QLatin1String("*.")) == 0){
     searchStr = searchStr.remove(0, 2);
-    searchStr.insert(0, "\\S+\\.");
+    searchStr.insert(0, QLatin1String("\\S+\\."));
   }
 
   if (searchStr.indexOf(QLatin1String("*")) == 0){
     searchStr = searchStr.remove(0, 1);
-    searchStr.insert(0, "\\S+");
+    searchStr.insert(0, QLatin1String("\\S+"));
   }
 
   if (searchStr.endsWith(QLatin1String("*"))){
     searchStr.remove(searchStr.length()-1, 1);
-    searchStr.append("\\S*");
+    searchStr.append(QLatin1String("\\S*"));
   }
 
   if (searchStr.indexOf(QLatin1String("^")) == -1 && searchStr.indexOf(QLatin1String("\\S")) != 0){
-    if (!exactMatch) searchStr.insert(0, "\\S*");
-    else searchStr.insert(0, "^");
+    if (!exactMatch) searchStr.insert(0, QLatin1String("\\S*"));
+    else searchStr.insert(0, QLatin1Char('^'));
   }
 
   if (searchStr.indexOf(QLatin1String("$")) == -1){
-    if (!exactMatch && !searchStr.endsWith(QLatin1String("\\S*"))) searchStr.append("\\S*");
-    else searchStr.append("$");
+    if (!exactMatch && !searchStr.endsWith(QLatin1String("\\S*"))) searchStr.append(QLatin1String("\\S*"));
+    else searchStr.append(QLatin1Char('$'));
   }
 
   searchStr.replace(QLatin1String("?"), QLatin1String("."));

--- a/src/package.h
+++ b/src/package.h
@@ -42,7 +42,7 @@ struct PackageListData{
   int     popularity; //votes
   PackageStatus status;
 
-  PackageListData() : name(""),
+  PackageListData() : name(QLatin1String("")),
                     downloadSize(0.0),
                     popularity(0),
                     status(ectn_NON_INSTALLED){
@@ -56,7 +56,7 @@ struct PackageListData{
                                     status(ectn_NON_INSTALLED){
   }
 
-  PackageListData(QString n, QString r, QString v, PackageStatus pkgStatus, QString outVersion="")
+  PackageListData(QString n, QString r, QString v, PackageStatus pkgStatus, QString outVersion=QLatin1String(""))
                                     : name(n),
                                     repository(r),
                                     version(v),
@@ -67,7 +67,7 @@ struct PackageListData{
   }
 
   PackageListData(QString n, QString r, QString v, QString d, PackageStatus pkgStatus,
-                  double downSize, QString outVersion="")
+                  double downSize, QString outVersion=QLatin1String(""))
                                     : name(n),
                                     repository(r),
                                     version(v),
@@ -78,7 +78,7 @@ struct PackageListData{
                                     status(pkgStatus){
   }
 
-  PackageListData(QString n, QString r, QString v, QString d, PackageStatus pkgStatus, QString outVersion="")
+  PackageListData(QString n, QString r, QString v, QString d, PackageStatus pkgStatus, QString outVersion=QLatin1String(""))
                                     : name(n),
                                     repository(r),
                                     version(v),
@@ -135,7 +135,7 @@ class Package{
     static QStringList * getOutdatedAURStringList();
     static QStringList * getPackageGroups();
     static QStringList * getPackagesOfGroup(const QString &groupName);
-    static QList<PackageListData> * getTargetUpgradeList(const QString &pkgName = "");
+    static QList<PackageListData> * getTargetUpgradeList(const QString &pkgName = QLatin1String(""));
     static QStringList * getTargetRemovalList(const QString &pkgName, const QString &removeCommand);
 
     static QList<PackageListData> *getForeignPackageList();

--- a/src/packagerepository.cpp
+++ b/src/packagerepository.cpp
@@ -333,7 +333,7 @@ bool PackageRepository::memberListOfGroupsEquals(const QStringList& listOfGroups
 PackageRepository::PackageData::PackageData(const PackageListData& pkg, const bool isRequired, const bool isManagedByAUR)
   : required(isRequired), managedByAUR(isManagedByAUR), name(pkg.name),
     repository(pkg.repository.isEmpty() ? StrConstants::getForeignRepositoryName() : pkg.repository),
-    version(pkg.version), description(pkg.description.toLatin1()), // octopi wants it converted to utf8
+    version(pkg.version), description(pkg.description), // octopi wants it converted to utf8
     outdatedVersion(pkg.outatedVersion), downloadSize(pkg.downloadSize),
     status(pkg.status != ectn_OUTDATED ?
            pkg.status :

--- a/src/pacmanexec.cpp
+++ b/src/pacmanexec.cpp
@@ -206,12 +206,12 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
   msg.remove(QRegularExpression(QStringLiteral(".+\\[Y/n\\].+")));
   //Let's remove color codes from strings...
 
-  msg.remove("\033[0;1m");
-  msg.remove("\033[0m");
+  msg.remove(QStringLiteral("\033[0;1m"));
+  msg.remove(QStringLiteral("\033[0m"));
   msg.remove(QStringLiteral("[1;33m"));
   msg.remove(QStringLiteral("[00;31m"));
-  msg.remove("\033[1;34m");
-  msg.remove("\033[0;1m");
+  msg.remove(QStringLiteral("\033[1;34m"));
+  msg.remove(QStringLiteral("\033[0;1m"));
   msg.remove(QStringLiteral("[1;1m"));
   msg.remove(QStringLiteral("[1;0m"));
   msg.remove(QStringLiteral("[1;m"));
@@ -238,7 +238,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
   }
   else if ((msg.indexOf(QLatin1String("resolving dependencies...")) != -1) && m_commandExecuting == ectn_SYSTEM_UPGRADE)
   {
-    msg = "<br>" + msg;
+    msg = QLatin1String("<br>") + msg;
   }
 
   if (SettingsManager::getShowPackageNumbersOutput())
@@ -274,7 +274,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
 
   else if (msg.contains(QLatin1String("download complete: ")))
   {
-    prepareTextToPrint(msg + "<br>");
+    prepareTextToPrint(msg + QLatin1String("<br>"));
     return;
   }
 
@@ -327,7 +327,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
         if (searchForKeyVerbs(msg))
         {
           int end = msg.indexOf(QLatin1String("["));
-          msg = msg.remove(end, msg.size()-end).trimmed() + " ";
+          msg = msg.remove(end, msg.size()-end).trimmed() + QLatin1Char(' ');
           prepareTextToPrint(msg);
         }
         else
@@ -337,7 +337,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
           if (pos >=0)
           {
             target = msg.left(pos);
-            target = target.trimmed() + " ";
+            target = target.trimmed() + QLatin1Char(' ');
 
             if (m_commandExecuting != ectn_SYNC_DATABASE &&
               (!target.contains(QLatin1String("-i686")) && !target.contains(QLatin1String("-x86_64")) && !target.contains(QLatin1String("-any")))) return; //WATCHOUT!
@@ -346,12 +346,12 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
 
             if(!target.isEmpty())
             {
-              prepareTextToPrint("<b><font color=\"#b4ab58\">" + target + "</font></b>"); //#C9BE62
+              prepareTextToPrint(QLatin1String("<b><font color=\"#b4ab58\">") + target + QLatin1String("</font></b>")); //#C9BE62
             }
           }
           else
           {
-            prepareTextToPrint("<b><font color=\"#b4ab58\">" + msg + "</font></b>"); //#C9BE62
+            prepareTextToPrint(QLatin1String("<b><font color=\"#b4ab58\">") + msg + QLatin1String("</font></b>")); //#C9BE62
           }
         }
       }
@@ -363,7 +363,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
 
           int end = msg.indexOf(QLatin1String("["));
           msg = msg.remove(end, msg.size()-end);
-          msg = msg.trimmed() + " ";
+          msg = msg.trimmed() + QLatin1Char(' ');
           prepareTextToPrint(msg);
         }
         else
@@ -372,7 +372,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
           if (pos >=0)
           {
             target = msg.left(pos);
-            target = target.trimmed() + " ";
+            target = target.trimmed() + QLatin1Char(' ');
             if (m_debugMode) std::cout << "target: " << target.toLatin1().data() << std::endl;
 
             if (m_commandExecuting != ectn_SYNC_DATABASE &&
@@ -384,20 +384,20 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
               {
                 if(m_commandExecuting == ectn_SYNC_DATABASE && !target.contains(QLatin1String("/")))
                 {
-                  prepareTextToPrint("<b><font color=\"#FF8040\">" +
-                                      StrConstants::getSyncing() + " " + target + "</font></b>");
+                  prepareTextToPrint(QLatin1String("<b><font color=\"#FF8040\">") +
+                                      StrConstants::getSyncing() + QLatin1Char(' ') + target + QLatin1String("</font></b>"));
                 }
                 else if (m_commandExecuting != ectn_SYNC_DATABASE)
                 {
-                  prepareTextToPrint("<b><font color=\"#b4ab58\">" +
-                                      target + "</font></b>"); //#C9BE62
+                  prepareTextToPrint(QLatin1String("<b><font color=\"#b4ab58\">") +
+                                      target + QLatin1String("</font></b>")); //#C9BE62
                 }
               }
             }
           }
           else
           {
-            prepareTextToPrint("<b><font color=\"blue\">" + msg + "</font></b>");
+            prepareTextToPrint(QLatin1String("<b><font color=\"blue\">") + msg + QLatin1String("</font></b>"));
           }
         }
       }
@@ -453,7 +453,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
 
     if (!msg.isEmpty())
     {
-      if (m_textPrinted.contains(msg + " ")) return;
+      if (m_textPrinted.contains(msg + QLatin1Char(' '))) return;
 
       if (msg.contains(QRegularExpression(QStringLiteral("removing")))) //&& !m_textPrinted.contains(msg + " "))
       {
@@ -463,7 +463,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
         if (pkgName.indexOf(QLatin1String("...")) != -1 || UnixCommand::isPackageInstalled(pkgName))
         {
           m_parsingAPackageChange = true;
-          prepareTextToPrint("<b><font color=\"#E55451\">" + msg + "</font></b>"); //RED
+          prepareTextToPrint(QLatin1String("<b><font color=\"#E55451\">") + msg + QLatin1String("</font></b>")); //RED
         }
       }
       else
@@ -471,7 +471,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
         QString altMsg = msg;
 
         if (msg.contains(QLatin1String(":: Updating")) && m_commandExecuting == ectn_SYNC_DATABASE)
-          prepareTextToPrint("<br><b>" + StrConstants::getSyncDatabases() + " (pkgfile -u)</b><br>");
+          prepareTextToPrint(QLatin1String("<br><b>") + StrConstants::getSyncDatabases() + QLatin1String(" (pkgfile -u)</b><br>"));
 
         else if (msg.contains(QLatin1String("download complete: ")))
           prepareTextToPrint(altMsg);
@@ -496,7 +496,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
                 repo.contains(QLatin1String("fontconfig"), Qt::CaseInsensitive) ||
                 repo.contains(QLatin1String("reading"), Qt::CaseInsensitive)) return;
 
-            altMsg = repo + " " + StrConstants::getIsUpToDate();
+            altMsg = repo + QLatin1Char(' ') + StrConstants::getIsUpToDate();
           }
 
           altMsg = Package::removeColorCodesFromStr(altMsg);
@@ -581,11 +581,11 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
         if (m_errorRetrievingFileCounter > 50) return;
       }
 
-      newStr = "<b><font color=\"#E55451\">" + newStr + "&nbsp;</font></b>"; //RED
+      newStr = QLatin1String("<b><font color=\"#E55451\">") + newStr + QLatin1String("&nbsp;</font></b>"); //RED
     }
     else if (newStr.contains(QLatin1String("warning"), Qt::CaseInsensitive) || (newStr.contains(QLatin1String("downgrading"))))
     {
-      newStr = "<b><font color=\"#FF8040\">" + newStr + "</font></b>"; //ORANGE
+      newStr = QLatin1String("<b><font color=\"#FF8040\">") + newStr + QLatin1String("</font></b>"); //ORANGE
     }
     else if(newStr.contains(QLatin1String("checking ")) ||
             newStr.contains(QLatin1String("is synced")) ||
@@ -599,12 +599,12 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
       {
         if (SettingsManager::getShowPackageNumbersOutput())
         {
-          newStr = "(" + QString::number(m_packageCounter) + "/" + QString::number(m_numberOfPackages) + ") " + newStr;
+          newStr = QLatin1Char('(') + QString::number(m_packageCounter) + QLatin1Char('/') + QString::number(m_numberOfPackages) + QLatin1String(") ") + newStr;
           if (m_packageCounter < m_numberOfPackages) m_packageCounter++;
         }
       }
 
-      newStr = "<b><font color=\"#4BC413\">" + newStr + "</font></b>"; //GREEN
+      newStr = QLatin1String("<b><font color=\"#4BC413\">") + newStr + QLatin1String("</font></b>"); //GREEN
     }
     else if (!newStr.contains(QLatin1String("::")))
     {
@@ -618,7 +618,7 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
   }
   else if (newStr.contains(QLatin1String("::")))
   {
-    newStr = "<br><B>" + newStr + "</B><br><br>";
+    newStr = QLatin1String("<br><B>") + newStr + QLatin1String("</B><br><br>");
 
     /*if (newStr.contains(":: Retrieving packages")) emit canStopTransaction(true);
     else if (newStr.contains(":: Processing package changes")) emit canStopTransaction(false);*/
@@ -645,14 +645,14 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
   if (SettingsManager::getShowPackageNumbersOutput() && m_commandExecuting != ectn_SYNC_DATABASE && newStr.contains(QLatin1String("#b4ab58")))
   {
     int c = newStr.indexOf(QLatin1String("#b4ab58\">")) + 9;
-    newStr.insert(c, "(" + QString::number(m_packageCounter) + "/" + QString::number(m_numberOfPackages) + ") ");
+    newStr.insert(c, QLatin1Char('(') + QString::number(m_packageCounter) + QLatin1Char('/') + QString::number(m_numberOfPackages) + QLatin1String(") "));
     if (m_packageCounter < m_numberOfPackages) m_packageCounter++;
   }
 
   if (SettingsManager::getShowPackageNumbersOutput() && m_parsingAPackageChange)
   {
     int c = newStr.indexOf(QLatin1String("#E55451\">")) + 9;
-    newStr.insert(c, "(" + QString::number(m_packageCounter) + "/" + QString::number(m_numberOfPackages) + ") ");
+    newStr.insert(c, QStringLiteral("(") + QString::number(m_packageCounter) + QLatin1Char('/') + QString::number(m_numberOfPackages) + QLatin1String(") "));
     if (m_packageCounter < m_numberOfPackages) m_packageCounter++;
   }
   //Package counter code...
@@ -675,35 +675,35 @@ void PacmanExec::onStarted()
   //First we output the name of action we are starting to execute!
   if (m_commandExecuting == ectn_CHECK_UPDATES)
   {
-    prepareTextToPrint("<b>" + StrConstants::getCheckingForUpdates() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getCheckingForUpdates() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_MIRROR_CHECK)
   {
-    prepareTextToPrint("<b>" + StrConstants::getSyncMirror() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getSyncMirror() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_SYNC_DATABASE)
   {
-    prepareTextToPrint("<b>" + StrConstants::getSyncDatabases() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getSyncDatabases() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_SYSTEM_UPGRADE || m_commandExecuting == ectn_RUN_SYSTEM_UPGRADE_IN_TERMINAL)
   {
-    prepareTextToPrint("<b>" + StrConstants::getSystemUpgradeMsg() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getSystemUpgradeMsg() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_REMOVE)
   {
-    prepareTextToPrint("<b>" + StrConstants::getRemovingPackages() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getRemovingPackages() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_INSTALL)
   {
-    prepareTextToPrint("<b>" + StrConstants::getInstallingPackages() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getInstallingPackages() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_REMOVE_INSTALL)
   {
-    prepareTextToPrint("<b>" + StrConstants::getRemovingAndInstallingPackages() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getRemovingAndInstallingPackages() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
   else if (m_commandExecuting == ectn_RUN_IN_TERMINAL)
   {
-    prepareTextToPrint("<b>" + StrConstants::getRunningCommandInTerminal() + "</b><br><br>", ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
+    prepareTextToPrint(QLatin1String("<b>") + StrConstants::getRunningCommandInTerminal() + QLatin1String("</b><br><br>"), ectn_DONT_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
   }
 
   QString output = m_unixCommand->readAllStandardOutput();
@@ -769,9 +769,9 @@ void PacmanExec::onReadOutput()
     QString output = m_unixCommand->readAllStandardOutput();
 
     output.remove(QStringLiteral("[01;33m"));
-    output.remove("\033[01;37m");
-    output.remove("\033[00m");
-    output.remove("\033[00;32m");
+    output.remove(QStringLiteral("\033[01;37m"));
+    output.remove(QStringLiteral("\033[00m"));
+    output.remove(QStringLiteral("\033[00;32m"));
     output.remove(QStringLiteral("[00;31m"));
     output.replace(QLatin1String("["), QLatin1String("'"));
     output.replace(QLatin1String("]"), QLatin1String("'"));
@@ -833,9 +833,9 @@ void PacmanExec::onReadOutputError()
     QString output = m_unixCommand->readAllStandardError();
 
     output.remove(QStringLiteral("[01;33m"));
-    output.remove("\033[01;37m");
-    output.remove("\033[00m");
-    output.remove("\033[00;32m");
+    output.remove(QStringLiteral("\033[01;37m"));
+    output.remove(QStringLiteral("\033[00m"));
+    output.remove(QStringLiteral("\033[00;32m"));
     output.remove(QStringLiteral("[00;31m"));
     output.remove(QStringLiteral("\n"));
 
@@ -924,21 +924,21 @@ void PacmanExec::doInstall(const QString &listOfPackages)
 
   if (isDatabaseLocked())
   {
-    command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
+    command += QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1String("; ");
   }
 
-  command += "pacman -S --noconfirm " + listOfPackages;
+  command += QLatin1String("pacman -S --noconfirm ") + listOfPackages;
 
   m_lastCommandList.clear();
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
   }
 
-  m_lastCommandList.append("pacman -S " + listOfPackages + ";");
+  m_lastCommandList.append(QLatin1String("pacman -S ") + listOfPackages + QLatin1Char(';'));
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_INSTALL;
   m_unixCommand->executeCommandWithSharedMemHelper(command, m_sharedMemory);
@@ -953,12 +953,12 @@ void PacmanExec::doInstallInTerminal(const QString &listOfPackages)
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
   }
 
-  m_lastCommandList.append("pacman -S " + listOfPackages);
+  m_lastCommandList.append(QLatin1String("pacman -S ") + listOfPackages);
   m_lastCommandList.append(QStringLiteral("echo -e"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runOctopiHelperInTerminalWithSharedMem(m_lastCommandList, m_sharedMemory);
@@ -975,7 +975,7 @@ void PacmanExec::doInstallLocal(const QString &listOfPackages)
 
   if (isDatabaseLocked())
   {
-    command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
+    command += QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1String("; ");
   }
 
   packages=listOfPackages.split(QStringLiteral(";"), QString::SkipEmptyParts);
@@ -984,29 +984,29 @@ void PacmanExec::doInstallLocal(const QString &listOfPackages)
   {
     if(p.trimmed().isEmpty()) continue;
     if (dontUseForce)
-      command += "pacman -U --noconfirm \"" + p.trimmed() + "\";";
+      command += QLatin1String("pacman -U --noconfirm \"") + p.trimmed() + QLatin1String("\";");
     else
-      command += "pacman -U --force --noconfirm \"" + p.trimmed() + "\";";
+      command += QLatin1String("pacman -U --force --noconfirm \"") + p.trimmed() + QLatin1String("\";");
   }
 
   m_lastCommandList.clear();
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
   }
 
   foreach(QString p, packages)
   {
     if(p.trimmed().isEmpty()) continue;
     if (dontUseForce)
-      m_lastCommandList.append("pacman -U \"" + p.trimmed() + "\";");
+      m_lastCommandList.append(QLatin1String("pacman -U \"") + p.trimmed() + QLatin1String("\";"));
     else
-      m_lastCommandList.append("pacman -U --force \"" + p.trimmed() + "\";");
+      m_lastCommandList.append(QLatin1String("pacman -U --force \"") + p.trimmed() + QLatin1String("\";"));
   }
 
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p '" + StrConstants::getPressAnyKey() + "'");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p '") + StrConstants::getPressAnyKey() + QLatin1Char('\''));
 
   m_commandExecuting = ectn_INSTALL;
   //std::cout << "COMMAND: " << command.toLatin1().data() << std::endl;
@@ -1026,8 +1026,8 @@ void PacmanExec::doInstallLocalInTerminal(const QString &listOfPackages)
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
-    command+="rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";";
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
+    command+=QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';');
   }
 
   packages=listOfPackages.split(QStringLiteral(";"), QString::SkipEmptyParts);
@@ -1038,19 +1038,19 @@ void PacmanExec::doInstallLocalInTerminal(const QString &listOfPackages)
 
     if (dontUseForce)
     {
-      command+="pacman -U \"" + p.trimmed() + "\";";
-      m_lastCommandList.append("pacman -U \"" + p.trimmed() + "\"");
+      command+=QLatin1String("pacman -U \"") + p.trimmed() + QLatin1String("\";");
+      m_lastCommandList.append(QLatin1String("pacman -U \"") + p.trimmed() + QLatin1Char('"'));
     }
     else
     {
-      command+="pacman -U --force \"" + p.trimmed() + "\";";
-      m_lastCommandList.append("pacman -U --force \"" + p.trimmed() + "\"");
+      command+=QLatin1String("pacman -U --force \"") + p.trimmed() + QLatin1String("\";");
+      m_lastCommandList.append(QLatin1String("pacman -U --force \"") + p.trimmed() + QLatin1Char('"'));
     }
   }
 
   m_lastCommandList.append(QStringLiteral("echo -e"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
-  command+="echo '" + StrConstants::getPressAnyKey() + "'";
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
+  command+=QLatin1String("echo '") + StrConstants::getPressAnyKey() + QLatin1Char('\'');
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   //std::cout << "COMMAND: " << command.toLatin1().data() << std::endl;
@@ -1066,21 +1066,21 @@ void PacmanExec::doRemove(const QString &listOfPackages)
 
   if (isDatabaseLocked())
   {
-    command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
+    command += QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1String("; ");
   }
 
-  command += "pacman -R --noconfirm " + listOfPackages;
+  command += QLatin1String("pacman -R --noconfirm ") + listOfPackages;
 
   m_lastCommandList.clear();
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
   }
 
-  m_lastCommandList.append("pacman -R " + listOfPackages + ";");
+  m_lastCommandList.append(QLatin1String("pacman -R ") + listOfPackages + QLatin1Char(';'));
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_REMOVE;  
   m_unixCommand->executeCommandWithSharedMemHelper(command, m_sharedMemory);
@@ -1095,12 +1095,12 @@ void PacmanExec::doRemoveInTerminal(const QString &listOfPackages)
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE);
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE);
   }
 
-  m_lastCommandList.append("pacman -R " + listOfPackages);
+  m_lastCommandList.append(QLatin1String("pacman -R ") + listOfPackages);
   m_lastCommandList.append(QStringLiteral("echo -e"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runOctopiHelperInTerminalWithSharedMem(m_lastCommandList, m_sharedMemory);
@@ -1115,22 +1115,22 @@ void PacmanExec::doRemoveAndInstall(const QString &listOfPackagestoRemove, const
 
   if (isDatabaseLocked())
   {
-    command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
+    command += QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1String("; ");
   }
 
-  command += "pacman -R --noconfirm " + listOfPackagestoRemove + "; pacman -S --noconfirm " + listOfPackagestoInstall;
+  command += QLatin1String("pacman -R --noconfirm ") + listOfPackagestoRemove + QLatin1String("; pacman -S --noconfirm ") + listOfPackagestoInstall;
 
   m_lastCommandList.clear();
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
   }
 
-  m_lastCommandList.append("pacman -R " + listOfPackagestoRemove + ";");
-  m_lastCommandList.append("pacman -S " + listOfPackagestoInstall + ";");
+  m_lastCommandList.append(QLatin1String("pacman -R ") + listOfPackagestoRemove + QLatin1Char(';'));
+  m_lastCommandList.append(QLatin1String("pacman -S ") + listOfPackagestoInstall + QLatin1Char(';'));
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_REMOVE_INSTALL;
   m_unixCommand->executeCommandWithSharedMemHelper(command, m_sharedMemory);
@@ -1145,13 +1145,13 @@ void PacmanExec::doRemoveAndInstallInTerminal(const QString &listOfPackagestoRem
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE);
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE);
   }
 
-  m_lastCommandList.append("pacman -R " + listOfPackagestoRemove);
-  m_lastCommandList.append("pacman -S " + listOfPackagestoInstall);
+  m_lastCommandList.append(QLatin1String("pacman -R ") + listOfPackagestoRemove);
+  m_lastCommandList.append(QLatin1String("pacman -S ") + listOfPackagestoInstall);
   m_lastCommandList.append(QStringLiteral("echo -e"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runOctopiHelperInTerminalWithSharedMem(m_lastCommandList, m_sharedMemory);
@@ -1166,7 +1166,7 @@ void PacmanExec::doSystemUpgrade()
 
   if (isDatabaseLocked())
   {
-    command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
+    command += QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1String("; ");
   }
 
   command += QLatin1String("pacman -Syu --noconfirm");
@@ -1175,12 +1175,12 @@ void PacmanExec::doSystemUpgrade()
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE + QLatin1Char(';'));
   }
 
   m_lastCommandList.append(QStringLiteral("pacman -Syu;"));
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_SYSTEM_UPGRADE;
   m_unixCommand->executeCommandWithSharedMemHelper(command, m_sharedMemory);
@@ -1195,7 +1195,7 @@ void PacmanExec::doSystemUpgradeInTerminal(CommandExecuting additionalCommand)
 
   if (isDatabaseLocked())
   {
-    m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE);
+    m_lastCommandList.append(QLatin1String("rm ") + ctn_PACMAN_DATABASE_LOCK_FILE);
   }
 
   if (additionalCommand == ectn_NONE)
@@ -1204,7 +1204,7 @@ void PacmanExec::doSystemUpgradeInTerminal(CommandExecuting additionalCommand)
     m_lastCommandList.append(QStringLiteral("pacman -Syu"));
 
   m_lastCommandList.append(QStringLiteral("echo -e"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_RUN_SYSTEM_UPGRADE_IN_TERMINAL;
   m_unixCommand->runOctopiHelperInTerminalWithSharedMem(m_lastCommandList, m_sharedMemory);
@@ -1219,27 +1219,27 @@ void PacmanExec::doAURUpgrade(const QString &listOfPackages)
 
   if (Package::getForeignRepositoryToolName() == ctn_PACAUR_TOOL)
   {
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -Sa " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -Sa ") + listOfPackages + QLatin1Char(';'));
   }
   else if (Package::getForeignRepositoryToolName() == ctn_YAOURT_TOOL)
   {
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -S ") + listOfPackages + QLatin1Char(';'));
   }
   else if (Package::getForeignRepositoryToolName() == ctn_TRIZEN_TOOL)
   {
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -Sa " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -Sa ") + listOfPackages + QLatin1Char(';'));
   }
   else if (Package::getForeignRepositoryToolName() == ctn_PIKAUR_TOOL)
   {
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S --aur " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -S --aur ") + listOfPackages + QLatin1Char(';'));
   }
   else if (Package::getForeignRepositoryToolName() == ctn_YAY_TOOL)
   {
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -S ") + listOfPackages + QLatin1Char(';'));
   }
 
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runCommandInTerminalAsNormalUser(m_lastCommandList);
@@ -1253,22 +1253,22 @@ void PacmanExec::doAURInstall(const QString &listOfPackages)
   m_lastCommandList.clear();
 
   if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -i " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -i ") + listOfPackages + QLatin1Char(';'));
   else if (Package::getForeignRepositoryToolName() == ctn_PACAUR_TOOL)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -Sa " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -Sa ") + listOfPackages + QLatin1Char(';'));
   else if (Package::getForeignRepositoryToolName() == ctn_YAOURT_TOOL)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -S ") + listOfPackages + QLatin1Char(';'));
   else if (Package::getForeignRepositoryToolName() == ctn_TRIZEN_TOOL)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -Sa " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -Sa ") + listOfPackages + QLatin1Char(';'));
   else if (Package::getForeignRepositoryToolName() == ctn_PIKAUR_TOOL)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S --aur " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -S --aur ") + listOfPackages + QLatin1Char(';'));
   else if (Package::getForeignRepositoryToolName() == ctn_YAY_TOOL)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S --aur " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -S --aur ") + listOfPackages + QLatin1Char(';'));
   else if (Package::getForeignRepositoryToolName() == ctn_CHASER_TOOL)
-    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " install " + listOfPackages + ";");
+    m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + QLatin1String(" install ") + listOfPackages + QLatin1Char(';'));
 
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runCommandInTerminalAsNormalUser(m_lastCommandList);
@@ -1280,11 +1280,11 @@ void PacmanExec::doAURInstall(const QString &listOfPackages)
 void PacmanExec::doInstallYayUsingTempYay()
 {
   m_lastCommandList.clear();
-  QString octopiConfDir = QDir::homePath() + QDir::separator() + ".config/octopi";
-  QString cmd = octopiConfDir + QDir::separator() + "yay --noconfirm --noeditmenu -S yay-bin;";
+  QString octopiConfDir = QDir::homePath() + QDir::separator() + QLatin1String(".config/octopi");
+  QString cmd = octopiConfDir + QDir::separator() + QLatin1String("yay --noconfirm --noeditmenu -S yay-bin;");
   m_lastCommandList.append(cmd);
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runCommandInTerminalAsNormalUser(m_lastCommandList);
 }
@@ -1299,16 +1299,16 @@ void PacmanExec::doAURRemove(const QString &listOfPackages)
       Package::getForeignRepositoryToolName() == ctn_KCP_TOOL ||
       Package::getForeignRepositoryToolName() == ctn_PIKAUR_TOOL)
   {
-    m_lastCommandList.append("pacman -R " + listOfPackages + ";");
+    m_lastCommandList.append(QLatin1String("pacman -R ") + listOfPackages + QLatin1Char(';'));
   }
   else
   {
     m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() +
-                             " -R " + listOfPackages + ";");
+                             QLatin1String(" -R ") + listOfPackages + QLatin1Char(';'));
   }
 
   m_lastCommandList.append(QStringLiteral("echo -e;"));
-  m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
+  m_lastCommandList.append(QLatin1String("read -n 1 -p \"") + StrConstants::getPressAnyKey() + QLatin1Char('"'));
 
   if (Package::getForeignRepositoryToolName() == ctn_KCP_TOOL)
     m_commandExecuting = ectn_REMOVE_KCP_PKG;

--- a/src/pacmanexec.cpp
+++ b/src/pacmanexec.cpp
@@ -107,15 +107,15 @@ int PacmanExec::cancelProcess()
  */
 bool PacmanExec::searchForKeyVerbs(QString output)
 {
-  return (output.contains(QRegularExpression("Arming ")) ||
-          output.contains(QRegularExpression("checking ")) ||
+  return (output.contains(QRegularExpression(QStringLiteral("Arming "))) ||
+          output.contains(QRegularExpression(QStringLiteral("checking "))) ||
           //output.contains(QRegularExpression("loading ")) ||
-          output.contains(QRegularExpression("installing ")) ||
-          output.contains(QRegularExpression("upgrading ")) ||
-          output.contains(QRegularExpression("downgrading ")) ||
+          output.contains(QRegularExpression(QStringLiteral("installing "))) ||
+          output.contains(QRegularExpression(QStringLiteral("upgrading "))) ||
+          output.contains(QRegularExpression(QStringLiteral("downgrading "))) ||
           //output.contains(QRegularExpression("resolving ")) ||
           //output.contains(QRegularExpression("looking ")) ||
-          output.contains(QRegularExpression("removing ")));
+          output.contains(QRegularExpression(QStringLiteral("removing "))));
 }
 
 /*
@@ -129,16 +129,16 @@ bool PacmanExec::splitOutputStrings(QString output)
   bool res = true;
 
   QString msg = output.trimmed();
-  QStringList msgs = msg.split(QRegularExpression("\\n"), QString::SkipEmptyParts);
+  QStringList msgs = msg.split(QRegularExpression(QStringLiteral("\\n")), QString::SkipEmptyParts);
 
   foreach (QString m, msgs)
   {
-    QStringList m2 = m.split(QRegularExpression("\\(\\s{0,3}[0-9]{1,4}/[0-9]{1,4}\\) "), QString::SkipEmptyParts);
+    QStringList m2 = m.split(QRegularExpression(QStringLiteral("\\(\\s{0,3}[0-9]{1,4}/[0-9]{1,4}\\) ")), QString::SkipEmptyParts);
 
     if (m2.count() == 1)
     {
       //Let's try another test... if it doesn't work, we give up.
-      QStringList maux = m.split(QRegularExpression("%"), QString::SkipEmptyParts);
+      QStringList maux = m.split(QRegularExpression(QStringLiteral("%")), QString::SkipEmptyParts);
       if (maux.count() > 1)
       {
         foreach (QString aux, maux)
@@ -148,7 +148,7 @@ bool PacmanExec::splitOutputStrings(QString output)
           {
             if (aux.at(aux.count()-1).isDigit())
             {
-              aux += "%";
+              aux += QLatin1String("%");
             }
 
             if (m_debugMode) std::cout << "_split - case1: " << aux.toLatin1().data() << std::endl;
@@ -203,53 +203,53 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
   QString progressRun;
   QString progressEnd;
 
-  msg.remove(QRegularExpression(".+\\[Y/n\\].+"));
+  msg.remove(QRegularExpression(QStringLiteral(".+\\[Y/n\\].+")));
   //Let's remove color codes from strings...
 
   msg.remove("\033[0;1m");
   msg.remove("\033[0m");
-  msg.remove("[1;33m");
-  msg.remove("[00;31m");
+  msg.remove(QStringLiteral("[1;33m"));
+  msg.remove(QStringLiteral("[00;31m"));
   msg.remove("\033[1;34m");
   msg.remove("\033[0;1m");
-  msg.remove("[1;1m");
-  msg.remove("[1;0m");
-  msg.remove("[1;m");
-  msg.remove("[1");
-  msg.remove("c");
-  msg.remove("C");
-  msg.remove("");
-  msg.remove("[m[0;37m");
-  msg.remove("o");
-  msg.remove("[m");
-  msg.remove(";37m");
-  msg.remove("[c");
-  msg.remove("[mo");
-  msg.remove("[32m");
-  msg.remove("(B[m");
+  msg.remove(QStringLiteral("[1;1m"));
+  msg.remove(QStringLiteral("[1;0m"));
+  msg.remove(QStringLiteral("[1;m"));
+  msg.remove(QStringLiteral("[1"));
+  msg.remove(QStringLiteral("c"));
+  msg.remove(QStringLiteral("C"));
+  msg.remove(QStringLiteral(""));
+  msg.remove(QStringLiteral("[m[0;37m"));
+  msg.remove(QStringLiteral("o"));
+  msg.remove(QStringLiteral("[m"));
+  msg.remove(QStringLiteral(";37m"));
+  msg.remove(QStringLiteral("[c"));
+  msg.remove(QStringLiteral("[mo"));
+  msg.remove(QStringLiteral("[32m"));
+  msg.remove(QStringLiteral("(B[m"));
 
   if (storeMsgCache) msgCache+=msg;
 
-  if (msg.indexOf(":: Synchronizing package databases...") != -1)
+  if (msg.indexOf(QLatin1String(":: Synchronizing package databases...")) != -1)
     m_commandExecuting = ectn_SYNC_DATABASE;
-  else if (msg.indexOf(":: Starting full system upgrade...") != -1)
+  else if (msg.indexOf(QLatin1String(":: Starting full system upgrade...")) != -1)
   {
     m_commandExecuting = ectn_SYSTEM_UPGRADE;
   }
-  else if ((msg.indexOf("resolving dependencies...") != -1) && m_commandExecuting == ectn_SYSTEM_UPGRADE)
+  else if ((msg.indexOf(QLatin1String("resolving dependencies...")) != -1) && m_commandExecuting == ectn_SYSTEM_UPGRADE)
   {
     msg = "<br>" + msg;
   }
 
   if (SettingsManager::getShowPackageNumbersOutput())
   {
-    QRegularExpression re("Packages? \\(\\d+\\)");
+    QRegularExpression re(QStringLiteral("Packages? \\(\\d+\\)"));
     QRegularExpressionMatch match = re.match(msg);
     if (match.hasMatch())
     {
       QString aux_packages = match.captured(0);
-      aux_packages.remove(QRegularExpression("Packages? \\("));
-      aux_packages.remove(")");
+      aux_packages.remove(QRegularExpression(QStringLiteral("Packages? \\(")));
+      aux_packages.remove(QStringLiteral(")"));
       m_numberOfPackages = aux_packages.toInt();
 
       if (m_numberOfPackages > 0) m_packageCounter = 1;
@@ -257,22 +257,22 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
     }
   }
 
-  if (msg.contains("Total Download Size:"))
+  if (msg.contains(QLatin1String("Total Download Size:")))
   {
     storeMsgCache=false;
     msgCache.clear();
 
     //If we ever find a "pacman" package being updated in GUI mode, let's stop this transaction: potential breakage!
-    if (msgCache.contains(QRegularExpression(".+Packages? \\(\\d+\\).+pacman-[0-9].+Total Download Size:.+")))
+    if (msgCache.contains(QRegularExpression(QStringLiteral(".+Packages? \\(\\d+\\).+pacman-[0-9].+Total Download Size:.+"))))
     {
       cancelProcess();
     }
   }
   else if (/*msg.contains("exists in filesystem") ||*/
-      (msg.contains(":: waiting for 1 process to finish repacking")) ||
-      (msg.contains(":: download complete in"))) return;
+      (msg.contains(QLatin1String(":: waiting for 1 process to finish repacking"))) ||
+      (msg.contains(QLatin1String(":: download complete in")))) return;
 
-  else if (msg.contains("download complete: "))
+  else if (msg.contains(QLatin1String("download complete: ")))
   {
     prepareTextToPrint(msg + "<br>");
     return;
@@ -282,19 +282,19 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
 
   if (m_iLoveCandy)
   {
-    progressRun = "m]";
-    progressEnd = "100%";
+    progressRun = QStringLiteral("m]");
+    progressEnd = QStringLiteral("100%");
   }
   else
   {
-    progressRun = "-]";
-    progressEnd = "#]";
+    progressRun = QStringLiteral("-]");
+    progressEnd = QStringLiteral("#]");
   }
 
   //If it is a percentage, we are talking about curl output...
   if(msg.indexOf(progressEnd) != -1)
   {
-    perc = "100%";
+    perc = QStringLiteral("100%");
     emit percentage(100);
     continueTesting = true;
   }
@@ -308,7 +308,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
 
     continueTesting = false;
 
-    int aux = msg.indexOf("[");
+    int aux = msg.indexOf(QLatin1String("["));
     if (aux > 0 && !msg.at(aux-1).isSpace()) return;
 
     QString target;
@@ -318,29 +318,29 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
         m_commandExecuting == ectn_REMOVE ||
         m_commandExecuting == ectn_REMOVE_INSTALL)
     {
-      int ini = msg.indexOf(QRegularExpression("\\(\\s{0,3}[0-9]{1,4}/[0-9]{1,4}\\) "));
+      int ini = msg.indexOf(QRegularExpression(QStringLiteral("\\(\\s{0,3}[0-9]{1,4}/[0-9]{1,4}\\) ")));
       if (ini == 0)
       {
-        int rp = msg.indexOf(")");
+        int rp = msg.indexOf(QLatin1String(")"));
         msg = msg.remove(0, rp+2);
 
         if (searchForKeyVerbs(msg))
         {
-          int end = msg.indexOf("[");
+          int end = msg.indexOf(QLatin1String("["));
           msg = msg.remove(end, msg.size()-end).trimmed() + " ";
           prepareTextToPrint(msg);
         }
         else
         {
           if (m_debugMode) std::cout << "test1: " << target.toLatin1().data() << std::endl;
-          int pos = msg.indexOf(" ");
+          int pos = msg.indexOf(QLatin1String(" "));
           if (pos >=0)
           {
             target = msg.left(pos);
             target = target.trimmed() + " ";
 
             if (m_commandExecuting != ectn_SYNC_DATABASE &&
-              (!target.contains("-i686") && !target.contains("-x86_64") && !target.contains("-any"))) return; //WATCHOUT!
+              (!target.contains(QLatin1String("-i686")) && !target.contains(QLatin1String("-x86_64")) && !target.contains(QLatin1String("-any")))) return; //WATCHOUT!
 
             if (m_debugMode) std::cout << "target: " << target.toLatin1().data() << std::endl;
 
@@ -361,14 +361,14 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
         {
           if (m_debugMode) std::cout << "test2: " << msg.toLatin1().data() << std::endl;
 
-          int end = msg.indexOf("[");
+          int end = msg.indexOf(QLatin1String("["));
           msg = msg.remove(end, msg.size()-end);
           msg = msg.trimmed() + " ";
           prepareTextToPrint(msg);
         }
         else
         {
-          int pos = msg.indexOf(" ");
+          int pos = msg.indexOf(QLatin1String(" "));
           if (pos >=0)
           {
             target = msg.left(pos);
@@ -376,13 +376,13 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
             if (m_debugMode) std::cout << "target: " << target.toLatin1().data() << std::endl;
 
             if (m_commandExecuting != ectn_SYNC_DATABASE &&
-              (!target.contains("-i686") && !target.contains("-x86_64") && !target.contains("-any"))) return; //WATCHOUT!
+              (!target.contains(QLatin1String("-i686")) && !target.contains(QLatin1String("-x86_64")) && !target.contains(QLatin1String("-any")))) return; //WATCHOUT!
 
             if(!target.isEmpty() && !m_textPrinted.contains(target))
             {
-              if (target.indexOf(QRegularExpression("[a-z]+")) != -1)
+              if (target.indexOf(QRegularExpression(QStringLiteral("[a-z]+"))) != -1)
               {
-                if(m_commandExecuting == ectn_SYNC_DATABASE && !target.contains("/"))
+                if(m_commandExecuting == ectn_SYNC_DATABASE && !target.contains(QLatin1String("/")))
                 {
                   prepareTextToPrint("<b><font color=\"#FF8040\">" +
                                       StrConstants::getSyncing() + " " + target + "</font></b>");
@@ -404,7 +404,7 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
     }
 
     //Here we print the transaction percentage updating
-    if(!perc.isEmpty() && perc.indexOf("%") > 0)
+    if(!perc.isEmpty() && perc.indexOf(QLatin1String("%")) > 0)
     {
       int ipercentage = perc.leftRef(perc.size()-1).toInt();
       emit percentage(ipercentage);
@@ -414,39 +414,39 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
   else
   {
     //Let's supress some annoying string bugs...
-    msg.remove(QRegularExpression("Don't need password!!"));
-    msg.remove(QRegularExpression("\\(process.+"));
-    msg.remove(QRegularExpression("QXcbConnection: XCB error:.+"));
-    msg.remove(QRegularExpression("Using the fallback.+"));
-    msg.remove(QRegularExpression("Gkr-Message:.+"));
-    msg.remove(QRegularExpression("kdesu.+"));
-    msg.remove(QRegularExpression("kbuildsycoca.+"));
-    msg.remove(QRegularExpression("Connecting to deprecated signal.+"));
-    msg.remove(QRegularExpression("QVariant.+"));
-    msg.remove(QRegularExpression("gksu-run.+"));
-    msg.remove(QRegularExpression("GConf Error:.+"));
-    msg.remove(QRegularExpression(":: Do.*"));
-    msg.remove(QRegularExpression("org\\.kde\\."));
-    msg.remove(QRegularExpression("QCommandLineParser"));
-    msg.remove(QRegularExpression("QCoreApplication.+"));
-    msg.remove(QRegularExpression("Fontconfig warning.+"));
-    msg.remove(QRegularExpression("reading configurations from.+"));
-    msg.remove(QRegularExpression(".+annot load library.+"));
-    msg.remove(QRegularExpression("libGL error.+"));
-    msg.remove(QRegularExpression("qt5ct:.+"));
-    msg.remove(QRegularExpression("(lxqt|octopi)-sudo:.+"));
-    msg.remove(QRegularExpression("qt.qpa.plugin:.+"));
-    msg.remove(QRegularExpression("qt.qpa.xcb:.+"));
-    msg.remove(QRegularExpression("Icon theme \".+"));
+    msg.remove(QRegularExpression(QStringLiteral("Don't need password!!")));
+    msg.remove(QRegularExpression(QStringLiteral("\\(process.+")));
+    msg.remove(QRegularExpression(QStringLiteral("QXcbConnection: XCB error:.+")));
+    msg.remove(QRegularExpression(QStringLiteral("Using the fallback.+")));
+    msg.remove(QRegularExpression(QStringLiteral("Gkr-Message:.+")));
+    msg.remove(QRegularExpression(QStringLiteral("kdesu.+")));
+    msg.remove(QRegularExpression(QStringLiteral("kbuildsycoca.+")));
+    msg.remove(QRegularExpression(QStringLiteral("Connecting to deprecated signal.+")));
+    msg.remove(QRegularExpression(QStringLiteral("QVariant.+")));
+    msg.remove(QRegularExpression(QStringLiteral("gksu-run.+")));
+    msg.remove(QRegularExpression(QStringLiteral("GConf Error:.+")));
+    msg.remove(QRegularExpression(QStringLiteral(":: Do.*")));
+    msg.remove(QRegularExpression(QStringLiteral("org\\.kde\\.")));
+    msg.remove(QRegularExpression(QStringLiteral("QCommandLineParser")));
+    msg.remove(QRegularExpression(QStringLiteral("QCoreApplication.+")));
+    msg.remove(QRegularExpression(QStringLiteral("Fontconfig warning.+")));
+    msg.remove(QRegularExpression(QStringLiteral("reading configurations from.+")));
+    msg.remove(QRegularExpression(QStringLiteral(".+annot load library.+")));
+    msg.remove(QRegularExpression(QStringLiteral("libGL error.+")));
+    msg.remove(QRegularExpression(QStringLiteral("qt5ct:.+")));
+    msg.remove(QRegularExpression(QStringLiteral("(lxqt|octopi)-sudo:.+")));
+    msg.remove(QRegularExpression(QStringLiteral("qt.qpa.plugin:.+")));
+    msg.remove(QRegularExpression(QStringLiteral("qt.qpa.xcb:.+")));
+    msg.remove(QRegularExpression(QStringLiteral("Icon theme \".+")));
     msg = msg.trimmed();
 
     if (m_debugMode) std::cout << "debug: " << msg.toLatin1().data() << std::endl;
 
     QString order;
-    int ini = msg.indexOf(QRegularExpression("\\(\\s{0,3}[0-9]{1,4}/[0-9]{1,4}\\) "));
+    int ini = msg.indexOf(QRegularExpression(QStringLiteral("\\(\\s{0,3}[0-9]{1,4}/[0-9]{1,4}\\) ")));
     if (ini == 0)
     {
-      int rp = msg.indexOf(")");
+      int rp = msg.indexOf(QLatin1String(")"));
       order = msg.left(rp+2);
       msg = msg.remove(0, rp+2);
     }
@@ -455,12 +455,12 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
     {
       if (m_textPrinted.contains(msg + " ")) return;
 
-      if (msg.contains(QRegularExpression("removing"))) //&& !m_textPrinted.contains(msg + " "))
+      if (msg.contains(QRegularExpression(QStringLiteral("removing")))) //&& !m_textPrinted.contains(msg + " "))
       {
         //Does this package exist or is it a proccessOutput buggy string???
         QString pkgName = msg.mid(9).trimmed();
 
-        if (pkgName.indexOf("...") != -1 || UnixCommand::isPackageInstalled(pkgName))
+        if (pkgName.indexOf(QLatin1String("...")) != -1 || UnixCommand::isPackageInstalled(pkgName))
         {
           m_parsingAPackageChange = true;
           prepareTextToPrint("<b><font color=\"#E55451\">" + msg + "</font></b>"); //RED
@@ -470,31 +470,31 @@ void PacmanExec::parsePacmanProcessOutput(const QString &output)
       {
         QString altMsg = msg;
 
-        if (msg.contains(":: Updating") && m_commandExecuting == ectn_SYNC_DATABASE)
+        if (msg.contains(QLatin1String(":: Updating")) && m_commandExecuting == ectn_SYNC_DATABASE)
           prepareTextToPrint("<br><b>" + StrConstants::getSyncDatabases() + " (pkgfile -u)</b><br>");
 
-        else if (msg.contains("download complete: "))
+        else if (msg.contains(QLatin1String("download complete: ")))
           prepareTextToPrint(altMsg);
 
-        else if (msg.indexOf(":: Synchronizing package databases...") == -1 &&
-            msg.indexOf(":: Starting full system upgrade...") == -1)
+        else if (msg.indexOf(QLatin1String(":: Synchronizing package databases...")) == -1 &&
+            msg.indexOf(QLatin1String(":: Starting full system upgrade...")) == -1)
         {
           if (m_debugMode) std::cout << "Print in black: " << msg.toLatin1().data() << std::endl;
 
           if (m_commandExecuting == ectn_SYNC_DATABASE &&
-              msg.contains("is up to date"))
+              msg.contains(QLatin1String("is up to date")))
           {
             emit percentage(100);
 
-            int blank = msg.indexOf(" ");
+            int blank = msg.indexOf(QLatin1String(" "));
             QString repo = msg.left(blank);
 
-            if (repo.contains("warning", Qt::CaseInsensitive) ||
-                repo.contains("error", Qt::CaseInsensitive) ||
-                repo.contains("gconf", Qt::CaseInsensitive) ||
-                repo.contains("failed", Qt::CaseInsensitive) ||
-                repo.contains("fontconfig", Qt::CaseInsensitive) ||
-                repo.contains("reading", Qt::CaseInsensitive)) return;
+            if (repo.contains(QLatin1String("warning"), Qt::CaseInsensitive) ||
+                repo.contains(QLatin1String("error"), Qt::CaseInsensitive) ||
+                repo.contains(QLatin1String("gconf"), Qt::CaseInsensitive) ||
+                repo.contains(QLatin1String("failed"), Qt::CaseInsensitive) ||
+                repo.contains(QLatin1String("fontconfig"), Qt::CaseInsensitive) ||
+                repo.contains(QLatin1String("reading"), Qt::CaseInsensitive)) return;
 
             altMsg = repo + " " + StrConstants::getIsUpToDate();
           }
@@ -521,26 +521,26 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
   }
 
   //If the string waiting to be printed is from curl status OR any other unwanted string...
-  if (!str.contains(QRegularExpression("<font color")))
-    if ((str.contains(QRegularExpression("\\(\\d")) &&
-         (!str.contains("target", Qt::CaseInsensitive)) &&
-         (!str.contains("package", Qt::CaseInsensitive))) ||
-        (str.contains(QRegularExpression("\\d\\)")) &&
-         (!str.contains("target", Qt::CaseInsensitive)) &&
-         (!str.contains("package", Qt::CaseInsensitive))) ||
+  if (!str.contains(QRegularExpression(QStringLiteral("<font color"))))
+    if ((str.contains(QRegularExpression(QStringLiteral("\\(\\d"))) &&
+         (!str.contains(QLatin1String("target"), Qt::CaseInsensitive)) &&
+         (!str.contains(QLatin1String("package"), Qt::CaseInsensitive))) ||
+        (str.contains(QRegularExpression(QStringLiteral("\\d\\)"))) &&
+         (!str.contains(QLatin1String("target"), Qt::CaseInsensitive)) &&
+         (!str.contains(QLatin1String("package"), Qt::CaseInsensitive))) ||
 
-        str.indexOf("Enter a selection", Qt::CaseInsensitive) == 0 ||
-        str.indexOf("Proceed with", Qt::CaseInsensitive) == 0 ||
-        str.indexOf("%") != -1 ||
+        str.indexOf(QLatin1String("Enter a selection"), Qt::CaseInsensitive) == 0 ||
+        str.indexOf(QLatin1String("Proceed with"), Qt::CaseInsensitive) == 0 ||
+        str.indexOf(QLatin1String("%")) != -1 ||
         //str.indexOf("[") != -1 ||
         //str.indexOf("]") != -1 ||
-        str.indexOf("---") != -1)
+        str.indexOf(QLatin1String("---")) != -1)
     {
       return;
     }
 
   //If the str waiting to being print has not yet been printed...
-  if(m_textPrinted.contains(str) && (!str.startsWith("==>") && !str.startsWith("->")))
+  if(m_textPrinted.contains(str) && (!str.startsWith(QLatin1String("==>")) && !str.startsWith(QLatin1String("->"))))
   {
     return;
   }
@@ -548,34 +548,34 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
   QString newStr = str;
 
   //If the string has already been colored...
-  if(newStr.contains(QRegularExpression("<font color")))
+  if(newStr.contains(QRegularExpression(QStringLiteral("<font color"))))
   {
-    newStr += "<br>";
+    newStr += QLatin1String("<br>");
   }
   //Otherwise, let's process the string to see if it needs to be colored
   else
   {
-    if(newStr.contains("removing ") ||
-       newStr.contains("could not ") ||
-       newStr.contains("error:", Qt::CaseInsensitive) ||
-       newStr.contains("failed") ||
-       newStr.contains("is not synced") ||
-       newStr.contains("could not be found") ||
+    if(newStr.contains(QLatin1String("removing ")) ||
+       newStr.contains(QLatin1String("could not ")) ||
+       newStr.contains(QLatin1String("error:"), Qt::CaseInsensitive) ||
+       newStr.contains(QLatin1String("failed")) ||
+       newStr.contains(QLatin1String("is not synced")) ||
+       newStr.contains(QLatin1String("could not be found")) ||
        newStr.contains(StrConstants::getCommandFinishedWithErrors()))
     {
       newStr = newStr.trimmed();
-      if (newStr.contains(QRegularExpression("removing \\S+$")))
+      if (newStr.contains(QRegularExpression(QStringLiteral("removing \\S+$"))))
       {
         //Does this package exist or is it a proccessOutput buggy string???
         QString pkgName = newStr.mid(9).trimmed();
 
-        if ((pkgName.indexOf("...") == -1) || UnixCommand::isPackageInstalled(pkgName))
+        if ((pkgName.indexOf(QLatin1String("...")) == -1) || UnixCommand::isPackageInstalled(pkgName))
         {
           m_parsingAPackageChange = true;
         }
       }
 
-      if (newStr.contains("failed retrieving file"))
+      if (newStr.contains(QLatin1String("failed retrieving file")))
       {
         m_errorRetrievingFileCounter++;
         if (m_errorRetrievingFileCounter > 50) return;
@@ -583,19 +583,19 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
 
       newStr = "<b><font color=\"#E55451\">" + newStr + "&nbsp;</font></b>"; //RED
     }
-    else if (newStr.contains("warning", Qt::CaseInsensitive) || (newStr.contains("downgrading")))
+    else if (newStr.contains(QLatin1String("warning"), Qt::CaseInsensitive) || (newStr.contains(QLatin1String("downgrading"))))
     {
       newStr = "<b><font color=\"#FF8040\">" + newStr + "</font></b>"; //ORANGE
     }
-    else if(newStr.contains("checking ") ||
-            newStr.contains("is synced") ||
-            newStr.contains("-- reinstalling") ||
-            newStr.contains("installing ") ||
-            newStr.contains("upgrading ")) /*||
+    else if(newStr.contains(QLatin1String("checking ")) ||
+            newStr.contains(QLatin1String("is synced")) ||
+            newStr.contains(QLatin1String("-- reinstalling")) ||
+            newStr.contains(QLatin1String("installing ")) ||
+            newStr.contains(QLatin1String("upgrading "))) /*||
             newStr.contains("loading "))*/
     {
       newStr = newStr.trimmed();
-      if (newStr.contains(QRegularExpression("installing \\S+$")) || newStr.contains(QRegularExpression("upgrading \\S+$")))
+      if (newStr.contains(QRegularExpression(QStringLiteral("installing \\S+$"))) || newStr.contains(QRegularExpression(QStringLiteral("upgrading \\S+$"))))
       {
         if (SettingsManager::getShowPackageNumbersOutput())
         {
@@ -606,17 +606,17 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
 
       newStr = "<b><font color=\"#4BC413\">" + newStr + "</font></b>"; //GREEN
     }
-    else if (!newStr.contains("::"))
+    else if (!newStr.contains(QLatin1String("::")))
     {
-      newStr += "<br>";
+      newStr += QLatin1String("<br>");
     }
   }//end of string coloring process
 
-  if (newStr.contains("Synchronizing databases... (pkgfile -u)"))
+  if (newStr.contains(QLatin1String("Synchronizing databases... (pkgfile -u)")))
   {
     emit canStopTransaction(false);
   }
-  else if (newStr.contains("::"))
+  else if (newStr.contains(QLatin1String("::")))
   {
     newStr = "<br><B>" + newStr + "</B><br><br>";
 
@@ -624,13 +624,13 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
     else if (newStr.contains(":: Processing package changes")) emit canStopTransaction(false);*/
 
     if (SettingsManager::getShowPackageNumbersOutput() &&
-        (newStr.contains(":: Retrieving packages") || (newStr.contains(":: Processing package changes"))))
+        (newStr.contains(QLatin1String(":: Retrieving packages")) || (newStr.contains(QLatin1String(":: Processing package changes")))))
         m_packageCounter = 1;
   }
 
-  if (!newStr.contains(QRegularExpression("<br"))) //It was an else!
+  if (!newStr.contains(QRegularExpression(QStringLiteral("<br")))) //It was an else!
   {
-    newStr += "<br>";
+    newStr += QLatin1String("<br>");
   }
 
   if (tl == ectn_TREAT_URL_LINK)
@@ -642,23 +642,23 @@ void PacmanExec::prepareTextToPrint(QString str, TreatString ts, TreatURLLinks t
   m_textPrinted.append(str);
 
   //Package counter code...
-  if (SettingsManager::getShowPackageNumbersOutput() && m_commandExecuting != ectn_SYNC_DATABASE && newStr.contains("#b4ab58"))
+  if (SettingsManager::getShowPackageNumbersOutput() && m_commandExecuting != ectn_SYNC_DATABASE && newStr.contains(QLatin1String("#b4ab58")))
   {
-    int c = newStr.indexOf("#b4ab58\">") + 9;
+    int c = newStr.indexOf(QLatin1String("#b4ab58\">")) + 9;
     newStr.insert(c, "(" + QString::number(m_packageCounter) + "/" + QString::number(m_numberOfPackages) + ") ");
     if (m_packageCounter < m_numberOfPackages) m_packageCounter++;
   }
 
   if (SettingsManager::getShowPackageNumbersOutput() && m_parsingAPackageChange)
   {
-    int c = newStr.indexOf("#E55451\">") + 9;
+    int c = newStr.indexOf(QLatin1String("#E55451\">")) + 9;
     newStr.insert(c, "(" + QString::number(m_packageCounter) + "/" + QString::number(m_numberOfPackages) + ") ");
     if (m_packageCounter < m_numberOfPackages) m_packageCounter++;
   }
   //Package counter code...
 
   //Let's insert in the ".pacnew" messages list if we found one!
-  if (newStr.contains(QRegularExpression("installed as \\S+.pacnew")))
+  if (newStr.contains(QRegularExpression(QStringLiteral("installed as \\S+.pacnew"))))
   {
     if (!m_listOfDotPacnewFiles.contains(newStr))
       m_listOfDotPacnewFiles.append(newStr);
@@ -730,15 +730,15 @@ void PacmanExec::onReadOutput()
     {
       //checkupdates outputs outdated packages like this: "apr 1.6.5-1 -> 1.7.0-1"
       if (m_listOfOutatedPackages.count() == 0)
-        m_listOfOutatedPackages = output.split("\n", QString::SkipEmptyParts);
+        m_listOfOutatedPackages = output.split(QStringLiteral("\n"), QString::SkipEmptyParts);
       else
       {
         //checkupdates returned more than 1 time from the QProcess event, so we have to concatenate the list...
         QString lastPackage = m_listOfOutatedPackages.last();
-        QStringList newList = output.split("\n", QString::SkipEmptyParts);
+        QStringList newList = output.split(QStringLiteral("\n"), QString::SkipEmptyParts);
         QString firstPackage = newList.first();
-        QStringList partsLast = lastPackage.split(" ", QString::SkipEmptyParts);
-        QStringList partsFirst = firstPackage.split(" ", QString::SkipEmptyParts);
+        QStringList partsLast = lastPackage.split(QStringLiteral(" "), QString::SkipEmptyParts);
+        QStringList partsFirst = firstPackage.split(QStringLiteral(" "), QString::SkipEmptyParts);
 
         if (partsLast.count()<4 || partsFirst.count()<4)
         {
@@ -750,14 +750,14 @@ void PacmanExec::onReadOutput()
         }
         else
         {
-          newList = output.split("\n", QString::SkipEmptyParts);
+          newList = output.split(QStringLiteral("\n"), QString::SkipEmptyParts);
           m_listOfOutatedPackages.append(newList);
         }
       }
     }
 
-    output.replace("\n", "<br>");
-    int i = output.lastIndexOf("<");
+    output.replace(QLatin1String("\n"), QLatin1String("<br>"));
+    int i = output.lastIndexOf(QLatin1String("<"));
     if (i != -1) output.remove(i, 4);
     prepareTextToPrint(output, ectn_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
 
@@ -768,18 +768,18 @@ void PacmanExec::onReadOutput()
   {
     QString output = m_unixCommand->readAllStandardOutput();
 
-    output.remove("[01;33m");
+    output.remove(QStringLiteral("[01;33m"));
     output.remove("\033[01;37m");
     output.remove("\033[00m");
     output.remove("\033[00;32m");
-    output.remove("[00;31m");
-    output.replace("[", "'");
-    output.replace("]", "'");
-    output.remove("\n");
+    output.remove(QStringLiteral("[00;31m"));
+    output.replace(QLatin1String("["), QLatin1String("'"));
+    output.replace(QLatin1String("]"), QLatin1String("'"));
+    output.remove(QStringLiteral("\n"));
 
-    if (output.contains("Checking", Qt::CaseInsensitive))
+    if (output.contains(QLatin1String("Checking"), Qt::CaseInsensitive))
     {
-      output += "<br>";
+      output += QLatin1String("<br>");
     }
 
     prepareTextToPrint(output, ectn_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
@@ -788,33 +788,33 @@ void PacmanExec::onReadOutput()
     return;
   }
 
-  if (WMHelper::getSUCommand().contains("kdesu"))
+  if (WMHelper::getSUCommand().contains(QLatin1String("kdesu")))
   {
     QString output = m_unixCommand->readAllStandardOutput();
 
     if (m_commandExecuting == ectn_SYNC_DATABASE &&
-        output.contains("Usage: /usr/bin/kdesu [options] command"))
+        output.contains(QLatin1String("Usage: /usr/bin/kdesu [options] command")))
     {
       emit readOutput();
       return;
     }
 
-    output = output.remove("Fontconfig warning: \"/etc/fonts/conf.d/50-user.conf\", line 14:");
-    output = output.remove("reading configurations from ~/.fonts.conf is deprecated. please move it to /home/arnt/.config/fontconfig/fonts.conf manually");
+    output = output.remove(QStringLiteral("Fontconfig warning: \"/etc/fonts/conf.d/50-user.conf\", line 14:"));
+    output = output.remove(QStringLiteral("reading configurations from ~/.fonts.conf is deprecated. please move it to /home/arnt/.config/fontconfig/fonts.conf manually"));
 
     if (!output.trimmed().isEmpty())
     {
       splitOutputStrings(output);
     }
   }
-  else if (WMHelper::getSUCommand().contains("gksu"))
+  else if (WMHelper::getSUCommand().contains(QLatin1String("gksu")))
   {
     QString output = m_unixCommand->readAllStandardOutput();
     output = output.trimmed();
 
     if(!output.isEmpty() &&
-       output.indexOf(":: Synchronizing package databases...") == -1 &&
-       output.indexOf(":: Starting full system upgrade...") == -1)
+       output.indexOf(QLatin1String(":: Synchronizing package databases...")) == -1 &&
+       output.indexOf(QLatin1String(":: Starting full system upgrade...")) == -1)
     {
       prepareTextToPrint(output);
     }
@@ -832,15 +832,15 @@ void PacmanExec::onReadOutputError()
   {
     QString output = m_unixCommand->readAllStandardError();
 
-    output.remove("[01;33m");
+    output.remove(QStringLiteral("[01;33m"));
     output.remove("\033[01;37m");
     output.remove("\033[00m");
     output.remove("\033[00;32m");
-    output.remove("[00;31m");
-    output.remove("\n");
+    output.remove(QStringLiteral("[00;31m"));
+    output.remove(QStringLiteral("\n"));
 
-    if (output.contains("Checking", Qt::CaseInsensitive))
-      output += "<br>";
+    if (output.contains(QLatin1String("Checking"), Qt::CaseInsensitive))
+      output += QLatin1String("<br>");
 
     prepareTextToPrint(output, ectn_TREAT_STRING, ectn_DONT_TREAT_URL_LINK);
 
@@ -849,8 +849,8 @@ void PacmanExec::onReadOutputError()
   }
 
   QString msg = m_unixCommand->readAllStandardError();
-  msg = msg.remove("Fontconfig warning: \"/etc/fonts/conf.d/50-user.conf\", line 14:");
-  msg = msg.remove("reading configurations from ~/.fonts.conf is deprecated. please move it to /home/arnt/.config/fontconfig/fonts.conf manually");
+  msg = msg.remove(QStringLiteral("Fontconfig warning: \"/etc/fonts/conf.d/50-user.conf\", line 14:"));
+  msg = msg.remove(QStringLiteral("reading configurations from ~/.fonts.conf is deprecated. please move it to /home/arnt/.config/fontconfig/fonts.conf manually"));
 
   if (!msg.trimmed().isEmpty())
   {
@@ -870,7 +870,7 @@ void PacmanExec::onFinished(int exitCode, QProcess::ExitStatus es)
     if (UnixCommand::getLinuxDistro() == ectn_KAOS &&
         UnixCommand::hasTheExecutable(ctn_KCP_TOOL))
 
-      UnixCommand::execCommandAsNormalUser("kcp -u");
+      UnixCommand::execCommandAsNormalUser(QStringLiteral("kcp -u"));
   }
 
   if (m_processWasCanceled && PacmanExec::isDatabaseLocked()) exitCode = -1;
@@ -937,7 +937,7 @@ void PacmanExec::doInstall(const QString &listOfPackages)
   }
 
   m_lastCommandList.append("pacman -S " + listOfPackages + ";");
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_INSTALL;
@@ -957,7 +957,7 @@ void PacmanExec::doInstallInTerminal(const QString &listOfPackages)
   }
 
   m_lastCommandList.append("pacman -S " + listOfPackages);
-  m_lastCommandList.append("echo -e");
+  m_lastCommandList.append(QStringLiteral("echo -e"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
@@ -978,7 +978,7 @@ void PacmanExec::doInstallLocal(const QString &listOfPackages)
     command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
   }
 
-  packages=listOfPackages.split(";", QString::SkipEmptyParts);
+  packages=listOfPackages.split(QStringLiteral(";"), QString::SkipEmptyParts);
 
   foreach(QString p, packages)
   {
@@ -1005,7 +1005,7 @@ void PacmanExec::doInstallLocal(const QString &listOfPackages)
       m_lastCommandList.append("pacman -U --force \"" + p.trimmed() + "\";");
   }
 
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p '" + StrConstants::getPressAnyKey() + "'");
 
   m_commandExecuting = ectn_INSTALL;
@@ -1030,7 +1030,7 @@ void PacmanExec::doInstallLocalInTerminal(const QString &listOfPackages)
     command+="rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";";
   }
 
-  packages=listOfPackages.split(";", QString::SkipEmptyParts);
+  packages=listOfPackages.split(QStringLiteral(";"), QString::SkipEmptyParts);
 
   foreach(QString p, packages)
   {
@@ -1048,7 +1048,7 @@ void PacmanExec::doInstallLocalInTerminal(const QString &listOfPackages)
     }
   }
 
-  m_lastCommandList.append("echo -e");
+  m_lastCommandList.append(QStringLiteral("echo -e"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
   command+="echo '" + StrConstants::getPressAnyKey() + "'";
 
@@ -1079,7 +1079,7 @@ void PacmanExec::doRemove(const QString &listOfPackages)
   }
 
   m_lastCommandList.append("pacman -R " + listOfPackages + ";");
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_REMOVE;  
@@ -1099,7 +1099,7 @@ void PacmanExec::doRemoveInTerminal(const QString &listOfPackages)
   }
 
   m_lastCommandList.append("pacman -R " + listOfPackages);
-  m_lastCommandList.append("echo -e");
+  m_lastCommandList.append(QStringLiteral("echo -e"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
@@ -1129,7 +1129,7 @@ void PacmanExec::doRemoveAndInstall(const QString &listOfPackagestoRemove, const
 
   m_lastCommandList.append("pacman -R " + listOfPackagestoRemove + ";");
   m_lastCommandList.append("pacman -S " + listOfPackagestoInstall + ";");
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_REMOVE_INSTALL;
@@ -1150,7 +1150,7 @@ void PacmanExec::doRemoveAndInstallInTerminal(const QString &listOfPackagestoRem
 
   m_lastCommandList.append("pacman -R " + listOfPackagestoRemove);
   m_lastCommandList.append("pacman -S " + listOfPackagestoInstall);
-  m_lastCommandList.append("echo -e");
+  m_lastCommandList.append(QStringLiteral("echo -e"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
@@ -1169,7 +1169,7 @@ void PacmanExec::doSystemUpgrade()
     command += "rm " + ctn_PACMAN_DATABASE_LOCK_FILE + "; ";
   }
 
-  command += "pacman -Syu --noconfirm";
+  command += QLatin1String("pacman -Syu --noconfirm");
 
   m_lastCommandList.clear();
 
@@ -1178,8 +1178,8 @@ void PacmanExec::doSystemUpgrade()
     m_lastCommandList.append("rm " + ctn_PACMAN_DATABASE_LOCK_FILE + ";");
   }
 
-  m_lastCommandList.append("pacman -Syu;");
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("pacman -Syu;"));
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_SYSTEM_UPGRADE;
@@ -1199,11 +1199,11 @@ void PacmanExec::doSystemUpgradeInTerminal(CommandExecuting additionalCommand)
   }
 
   if (additionalCommand == ectn_NONE)
-    m_lastCommandList.append("pacman -Syu");
+    m_lastCommandList.append(QStringLiteral("pacman -Syu"));
   else if (additionalCommand == ectn_SYNC_DATABASE)
-    m_lastCommandList.append("pacman -Syu");
+    m_lastCommandList.append(QStringLiteral("pacman -Syu"));
 
-  m_lastCommandList.append("echo -e");
+  m_lastCommandList.append(QStringLiteral("echo -e"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_RUN_SYSTEM_UPGRADE_IN_TERMINAL;
@@ -1238,7 +1238,7 @@ void PacmanExec::doAURUpgrade(const QString &listOfPackages)
     m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " -S " + listOfPackages + ";");
   }
 
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
@@ -1267,7 +1267,7 @@ void PacmanExec::doAURInstall(const QString &listOfPackages)
   else if (Package::getForeignRepositoryToolName() == ctn_CHASER_TOOL)
     m_lastCommandList.append(Package::getForeignRepositoryToolNameParam() + " install " + listOfPackages + ";");
 
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
@@ -1283,7 +1283,7 @@ void PacmanExec::doInstallYayUsingTempYay()
   QString octopiConfDir = QDir::homePath() + QDir::separator() + ".config/octopi";
   QString cmd = octopiConfDir + QDir::separator() + "yay --noconfirm --noeditmenu -S yay-bin;";
   m_lastCommandList.append(cmd);
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
   m_commandExecuting = ectn_RUN_IN_TERMINAL;
   m_unixCommand->runCommandInTerminalAsNormalUser(m_lastCommandList);
@@ -1307,7 +1307,7 @@ void PacmanExec::doAURRemove(const QString &listOfPackages)
                              " -R " + listOfPackages + ";");
   }
 
-  m_lastCommandList.append("echo -e;");
+  m_lastCommandList.append(QStringLiteral("echo -e;"));
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
   if (Package::getForeignRepositoryToolName() == ctn_KCP_TOOL)

--- a/src/repoconf.cpp
+++ b/src/repoconf.cpp
@@ -31,18 +31,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * Gets all the repos available in system's Pacman configuration
  */
 
-QString RepoConf::commentString = "";
+QString RepoConf::commentString = QLatin1String("");
 QRegularExpression RepoConf::repoMatch     = QRegularExpression();
 QRegularExpression RepoConf::detailMatch   = QRegularExpression();
 
 RepoConf::RepoConf():
-  m_repoConfFilePath("/etc/pacman.conf")
+  m_repoConfFilePath(QStringLiteral("/etc/pacman.conf"))
 {
-  repoMatch = QRegularExpression("^\\[(?!(options|repo-name|\\[|\\s))");
-  detailMatch = QRegularExpression("^(Server|Include)\\s*=\\s*.+");
-  RepoEntry::nameFilter = QRegularExpression("(\\s+|\\[|\\])");
-  commentString = "#";
-  RepoEntry::repoFormat = "[%repo%]";
+  repoMatch = QRegularExpression(QStringLiteral("^\\[(?!(options|repo-name|\\[|\\s))"));
+  detailMatch = QRegularExpression(QStringLiteral("^(Server|Include)\\s*=\\s*.+"));
+  RepoEntry::nameFilter = QRegularExpression(QStringLiteral("(\\s+|\\[|\\])"));
+  commentString = QStringLiteral("#");
+  RepoEntry::repoFormat = QStringLiteral("[%repo%]");
 
   loadConf( m_repoConfFilePath );
 }

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -51,10 +51,10 @@ void SearchBar::init()
   layout->setSpacing(0);
   layout->setMargin(4);
 
-  setStyleSheet("QWidget#searchbar{"
+  setStyleSheet(QLatin1String("QWidget#searchbar{"
                 "border-top-width: .6px;"
                 "border-top-style: solid;"
-                "border-top-color: darkgray;}");
+                "border-top-color: darkgray;}"));
 
   m_searchLineEdit = new SearchLineEdit(this);
   m_searchLineEdit->setMinimumWidth(300);
@@ -66,10 +66,10 @@ void SearchBar::init()
   QAction *m_previousAction = new QAction(this);
   QAction *m_nextAction = new QAction(this);
 
-  m_previousAction->setText("< " + tr("Previous"));
+  m_previousAction->setText(QLatin1String("< ") + tr("Previous"));
   m_previousButton->setAutoRaise(true);
   m_previousAction->setShortcut(QKeySequence(Qt::SHIFT + Qt::Key_F3));
-  m_nextAction->setText(tr("Next") + " >");
+  m_nextAction->setText(tr("Next") + QLatin1String(" >"));
   m_nextButton->setAutoRaise(true);
   m_nextAction->setShortcut(Qt::Key_F3);
   m_previousButton->setDefaultAction(m_previousAction);
@@ -79,9 +79,9 @@ void SearchBar::init()
   tbClose->setIcon(IconHelper::getIconClose());
 
   tbClose->setAutoRaise(true);
-  tbClose->setStyleSheet("QToolButton{ font-size: 16px; font-family: verdana; border-radius: 4px; } "
+  tbClose->setStyleSheet(QLatin1String("QToolButton{ font-size: 16px; font-family: verdana; border-radius: 4px; } "
                          "QToolButton:hover{ background-color: palette(light); }"
-                         "QToolButton::pressed{ background-color: palette(mid); }");
+                         "QToolButton::pressed{ background-color: palette(mid); }"));
 
   tbClose->setToolTip(tr("Close"));
   tbClose->setShortcut(Qt::Key_Escape);

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -46,7 +46,7 @@ SearchBar::SearchBar(QWidget *parent) :
 void SearchBar::init()
 {
   setVisible(false);
-  setObjectName("searchbar");
+  setObjectName(QStringLiteral("searchbar"));
   QHBoxLayout *layout = new QHBoxLayout(this);
   layout->setSpacing(0);
   layout->setMargin(4);
@@ -109,7 +109,7 @@ void SearchBar::close()
 {
   hide();
   disconnect(m_searchLineEdit, SIGNAL(textChanged(QString)), this, SIGNAL(textChanged(QString)));
-  m_searchLineEdit->setText("");
+  m_searchLineEdit->setText(QLatin1String(""));
   connect(m_searchLineEdit, SIGNAL(textChanged(QString)), this, SIGNAL(textChanged(QString)));
   emit closed();
 }
@@ -119,7 +119,7 @@ void SearchBar::close()
  */
 void SearchBar::clear()
 {
-  m_searchLineEdit->setText("");
+  m_searchLineEdit->setText(QLatin1String(""));
 }
 
 /*

--- a/src/searchlineedit.cpp
+++ b/src/searchlineedit.cpp
@@ -245,7 +245,7 @@ QString SearchLineEdit::buttonStyleSheetForCurrentState() const
   QString style;
   style += QLatin1String("QToolButton {");
   style += QLatin1String("border: none; margin: 0; padding: 0;");
-  style += QStringLiteral("background-image: url(:/resources/images/esf-%1.png);").arg(this->text().isEmpty() ? "search" : "clear");
+  style += QStringLiteral("background-image: url(:/resources/images/esf-%1.png);").arg(this->text().isEmpty() ? QStringLiteral("search") : QStringLiteral("clear"));
   style += QLatin1String("}");
 
   if (!this->text().isEmpty())

--- a/src/searchlineedit.cpp
+++ b/src/searchlineedit.cpp
@@ -46,9 +46,9 @@ SearchLineEdit::SearchLineEdit(QWidget *parent, bool hasSLocate) :
   this->m_SearchButton->setCursor(Qt::ArrowCursor);
   this->m_SearchButton->setStyleSheet(this->buttonStyleSheetForCurrentState());
 
-  m_defaultValidator = new QRegularExpressionValidator(QRegularExpression("[a-zA-Z0-9_\\-\\$\\^\\*\\+\\(\\)\\[\\]\\.\\s\\\\]+"), this);
-  m_aurValidator = new QRegularExpressionValidator(QRegularExpression("[a-zA-Z0-9_\\-\\+\\s\\\\]+"), this);
-  m_fileValidator = new QRegularExpressionValidator(QRegularExpression("[a-zA-Z0-9_\\-\\/\\.]+"), this);
+  m_defaultValidator = new QRegularExpressionValidator(QRegularExpression(QStringLiteral("[a-zA-Z0-9_\\-\\$\\^\\*\\+\\(\\)\\[\\]\\.\\s\\\\]+")), this);
+  m_aurValidator = new QRegularExpressionValidator(QRegularExpression(QStringLiteral("[a-zA-Z0-9_\\-\\+\\s\\\\]+")), this);
+  m_fileValidator = new QRegularExpressionValidator(QRegularExpression(QStringLiteral("[a-zA-Z0-9_\\-\\/\\.]+")), this);
   setValidator(m_defaultValidator);
 
   // Update the search button when the text changes
@@ -77,7 +77,7 @@ void SearchLineEdit::setRefreshValidator(ValidatorType validatorType)
   int pos = 0;
   QString search = text();
   if (this->validator()->validate(search, pos) == QValidator::Invalid)
-    setText("");
+    setText(QLatin1String(""));
 
   m_validatorType = validatorType;
 }
@@ -133,12 +133,12 @@ void SearchLineEdit::updateSearchButton(const QString &text)
 QString SearchLineEdit::styleSheetForCurrentState()
 { 
   QString style;
-  style += "QLineEdit {";
+  style += QLatin1String("QLineEdit {");
 
   if (UnixCommand::getLinuxDistro() != ectn_CHAKRA)
   {
-    style += "font-family: 'Sans Serif';";
-    style += "font-style: italic;";
+    style += QLatin1String("font-family: 'Sans Serif';");
+    style += QLatin1String("font-style: italic;");
   }
   else
   {
@@ -150,16 +150,16 @@ QString SearchLineEdit::styleSheetForCurrentState()
   if (!WMHelper::isKDERunning()) //UnixCommand::getLinuxDistro() != ectn_CHAKRA)
   {
     int frameWidth = 1;
-    style += "padding-left: 20px;";
-    style += QString("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + frameWidth + 1);
-    style += "border-width: 3px;}";
+    style += QLatin1String("padding-left: 20px;");
+    style += QStringLiteral("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + frameWidth + 1);
+    style += QLatin1String("border-width: 3px;}");
     //style += "border-image: url(:/resources/images/esf-border.png) 3 3 3 3 stretch;}";
     //style += "background-color: rgba(255, 255, 255, 255);"; //204);";
     //style += "color: black;}";
   }
   else
   {
-    style += "padding-left: 20px;}";
+    style += QLatin1String("padding-left: 20px;}");
     //setPalette(QApplication::palette());
   }
 
@@ -168,15 +168,15 @@ QString SearchLineEdit::styleSheetForCurrentState()
 
 void SearchLineEdit::setFoundStyle(){
   QString style;
-  style += "QLineEdit {";
+  style += QLatin1String("QLineEdit {");
 
   if (!WMHelper::isKDERunning()) //(UnixCommand::getLinuxDistro() != ectn_CHAKRA)
   {
-    style += "font-family: 'Sans Serif';";
-    style += "font-style: italic;";
-    style += "padding-left: 20px;";
-    style += QString("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + 2);
-    style += "border-width: 3px;}";
+    style += QLatin1String("font-family: 'Sans Serif';");
+    style += QLatin1String("font-style: italic;");
+    style += QLatin1String("padding-left: 20px;");
+    style += QStringLiteral("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + 2);
+    style += QLatin1String("border-width: 3px;}");
     //style += "border-image: url(:/resources/images/esf-border.png) 3 3 3 3 stretch;";
     //style += "color: black; ";
     //style += "background-color: rgb(255, 255, 255);";
@@ -186,7 +186,7 @@ void SearchLineEdit::setFoundStyle(){
   else
   // setPalette() must be called after setStyleSheet()
   {
-    style += "padding-left: 20px;}";
+    style += QLatin1String("padding-left: 20px;}");
     setStyleSheet(style);
 
     /*QPalette palette(QApplication::palette());
@@ -198,25 +198,25 @@ void SearchLineEdit::setFoundStyle(){
 
 void SearchLineEdit::setNotFoundStyle(){
   QString style;
-  style += "QLineEdit {";
+  style += QLatin1String("QLineEdit {");
 
   if (!WMHelper::isKDERunning()) //(UnixCommand::getLinuxDistro() != ectn_CHAKRA)
   {
-    style += "font-family: 'Sans Serif';";
-    style += "font-style: italic;";
-    style += "padding-left: 20px;";
-    style += QString("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + 2);
-    style += "border-width: 3px;";
+    style += QLatin1String("font-family: 'Sans Serif';");
+    style += QLatin1String("font-style: italic;");
+    style += QLatin1String("padding-left: 20px;");
+    style += QStringLiteral("padding-right: %1px;").arg(this->m_SearchButton->sizeHint().width() + 2);
+    style += QLatin1String("border-width: 3px;");
     //style += "border-image: url(:/resources/images/esf-border.png) 3 3 3 3 stretch;";
     //style += "color: white; ";
     //style += "background-color: lightgray;"; //rgb(255, 108, 108); //palette(mid);"; //rgb(207, 135, 142);";
-    style += "border-color: rgb(206, 204, 197);}";
+    style += QLatin1String("border-color: rgb(206, 204, 197);}");
     setStyleSheet(style);
   }
   // setPalette() must be called after setStyleSheet()
   else
   {
-    style += "padding-left: 20px;}";
+    style += QLatin1String("padding-left: 20px;}");
     setStyleSheet(style);
 
     /*QPalette palette(QApplication::palette());
@@ -237,23 +237,23 @@ QString SearchLineEdit::buttonStyleSheetForCurrentState() const
     if (!this->text().isEmpty())
       this->m_SearchButton->setToolTip(StrConstants::getClear());
     else
-      this->m_SearchButton->setToolTip("");
+      this->m_SearchButton->setToolTip(QLatin1String(""));
 
     return QString();
   }
 
   QString style;
-  style += "QToolButton {";
-  style += "border: none; margin: 0; padding: 0;";
-  style += QString("background-image: url(:/resources/images/esf-%1.png);").arg(this->text().isEmpty() ? "search" : "clear");
-  style += "}";
+  style += QLatin1String("QToolButton {");
+  style += QLatin1String("border: none; margin: 0; padding: 0;");
+  style += QStringLiteral("background-image: url(:/resources/images/esf-%1.png);").arg(this->text().isEmpty() ? "search" : "clear");
+  style += QLatin1String("}");
 
   if (!this->text().isEmpty())
   {
-    style += "QToolButton:pressed { background-image: url(:/resources/images/esf-clear.png); }";
+    style += QLatin1String("QToolButton:pressed { background-image: url(:/resources/images/esf-clear.png); }");
     this->m_SearchButton->setToolTip(StrConstants::getClear());
   }
-  else this->m_SearchButton->setToolTip("");
+  else this->m_SearchButton->setToolTip(QLatin1String(""));
 
   return style;
 }

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -297,7 +297,7 @@ QString SettingsManager::getDistroRSSUrl()
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://www.netrunner.com/feed/")).toString();*/
   else if (distro == ectn_PARABOLA)
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://www.parabola.nu/feeds/news/")).toString();
-  else return "";
+  else return QLatin1String("");
 }
 
 bool SettingsManager::getShowPackageNumbersOutput()
@@ -322,31 +322,31 @@ QString SettingsManager::getAURTool()
   if (ret == ctn_NO_AUR_TOOL) return ret;
   else if (ret == ctn_PACAUR_TOOL)
   {
-    if (getAURNoConfirmParam()) params += " --noconfirm ";
-    if (getAURNoEditParam()) params += " --noedit ";
+    if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+    if (getAURNoEditParam()) params += QLatin1String(" --noedit ");
     ret += params;
   }
   else if (ret == ctn_YAOURT_TOOL)
   {
-    if (getAURNoConfirmParam()) params += " --noconfirm ";
+    if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
     ret += params;
   }
   else if (ret == ctn_TRIZEN_TOOL)
   {
-    if (getAURNoConfirmParam()) params += " --noconfirm ";
-    if (getAURNoEditParam()) params += " --noedit ";
+    if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+    if (getAURNoEditParam()) params += QLatin1String(" --noedit ");
     ret += params;
   }
   else if (ret == ctn_PIKAUR_TOOL)
   {
-    if (getAURNoConfirmParam()) params += " --noconfirm ";
-    if (getAURNoEditParam()) params += " --noedit ";
+    if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+    if (getAURNoEditParam()) params += QLatin1String(" --noedit ");
     ret += params;
   }
   else if (ret == ctn_YAY_TOOL)
   {
-    if (getAURNoConfirmParam()) params += " --noconfirm ";
-    if (getAURNoEditParam()) params += " --noeditmenu ";
+    if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+    if (getAURNoEditParam()) params += QLatin1String(" --noeditmenu ");
     ret += params;
   }
   //System does not have selected aurtool. Let's see if there are any other available...
@@ -354,8 +354,8 @@ QString SettingsManager::getAURTool()
   {
     if (UnixCommand::hasTheExecutable(ctn_TRIZEN_TOOL))
     {
-      if (getAURNoConfirmParam()) params += " --noconfirm ";
-      if (getAURNoEditParam()) params += " --noedit ";
+      if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+      if (getAURNoEditParam()) params += QLatin1String(" --noedit ");
 
       p_instance.setAURTool(ctn_TRIZEN_TOOL);
       p_instance.getSYSsettings()->sync();
@@ -363,8 +363,8 @@ QString SettingsManager::getAURTool()
     }
     else if (UnixCommand::hasTheExecutable(ctn_PIKAUR_TOOL))
     {
-      if (getAURNoConfirmParam()) params += " --noconfirm ";
-      if (getAURNoEditParam()) params += " --noedit ";
+      if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+      if (getAURNoEditParam()) params += QLatin1String(" --noedit ");
 
       p_instance.setAURTool(ctn_PIKAUR_TOOL);
       p_instance.getSYSsettings()->sync();
@@ -372,8 +372,8 @@ QString SettingsManager::getAURTool()
     }
     else if (UnixCommand::hasTheExecutable(ctn_YAY_TOOL))
     {
-      if (getAURNoConfirmParam()) params += " --noconfirm ";
-      if (getAURNoEditParam()) params += " --noeditmenu ";
+      if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+      if (getAURNoEditParam()) params += QLatin1String(" --noeditmenu ");
 
       p_instance.setAURTool(ctn_YAY_TOOL);
       p_instance.getSYSsettings()->sync();
@@ -381,7 +381,7 @@ QString SettingsManager::getAURTool()
     }
     else if (UnixCommand::hasTheExecutable(ctn_YAOURT_TOOL))
     {
-      if (getAURNoConfirmParam()) params += " --noconfirm ";
+      if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
 
       p_instance.setAURTool(ctn_YAOURT_TOOL);
       p_instance.getSYSsettings()->sync();
@@ -389,8 +389,8 @@ QString SettingsManager::getAURTool()
     }
     else if (UnixCommand::hasTheExecutable(ctn_PACAUR_TOOL))
     {
-      if (getAURNoConfirmParam()) params += " --noconfirm ";
-      if (getAURNoEditParam()) params += " --noedit ";
+      if (getAURNoConfirmParam()) params += QLatin1String(" --noconfirm ");
+      if (getAURNoEditParam()) params += QLatin1String(" --noedit ");
 
       p_instance.setAURTool(ctn_PACAUR_TOOL);
       p_instance.getSYSsettings()->sync();
@@ -449,7 +449,7 @@ QString SettingsManager::getAURPassword()
   QByteArray encryptedValue = (p_instance.getSYSsettings()->value(ctn_KEY_AUR_PASSWORD, "")).toByteArray();
 
   QString aurUserName = getAURUserName();
-  if (aurUserName.isEmpty()) return "";
+  if (aurUserName.isEmpty()) return QLatin1String("");
 
   QByteArray hashKey = QCryptographicHash::hash(ctn_OCTOPI_COPYRIGHT.toLocal8Bit(), QCryptographicHash::Sha256);
   QByteArray hashIV = QCryptographicHash::hash(aurUserName.toLocal8Bit(), QCryptographicHash::Md5);

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -249,31 +249,31 @@ bool SettingsManager::getUseDefaultAppIcon()
 QString SettingsManager::getOctopiBusyIconPath()
 {
   SettingsManager p_instance;
-  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_BUSY_ICON_PATH, "")).toString();
+  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_BUSY_ICON_PATH, QLatin1String(""))).toString();
 }
 
 QString SettingsManager::getOctopiRedIconPath()
 {
   SettingsManager p_instance;
-  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_RED_ICON_PATH, "")).toString();
+  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_RED_ICON_PATH, QLatin1String(""))).toString();
 }
 
 QString SettingsManager::getOctopiYellowIconPath()
 {
   SettingsManager p_instance;
-  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_YELLOW_ICON_PATH, "")).toString();
+  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_YELLOW_ICON_PATH, QLatin1String(""))).toString();
 }
 
 QString SettingsManager::getOctopiGreenIconPath()
 {
   SettingsManager p_instance;
-  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_GREEN_ICON_PATH, "")).toString();
+  return (p_instance.getSYSsettings()->value(ctn_KEY_OCTOPI_GREEN_ICON_PATH, QLatin1String(""))).toString();
 }
 
 bool SettingsManager::isDistroRSSUrlEmpty()
 {
   SettingsManager p_instance;
-  return p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "").toString().isEmpty();
+  return p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QLatin1String("")).toString().isEmpty();
 }
 
 QString SettingsManager::getDistroRSSUrl()
@@ -282,21 +282,21 @@ QString SettingsManager::getDistroRSSUrl()
   LinuxDistro distro = UnixCommand::getLinuxDistro();
 
   if (distro == ectn_ARCHLINUX || distro == ectn_ARCHBANGLINUX /*|| distro == ectn_SWAGARCH*/)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://www.archlinux.org/feeds/news/")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://www.archlinux.org/feeds/news/"))).toString();
   else if (distro == ectn_CHAKRA)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://community.chakralinux.org/c/news.rss")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://community.chakralinux.org/c/news.rss"))).toString();
   else if (distro == ectn_CONDRESOS)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://condresos.codelinsoft.it/index.php/blog?format=feed&amp;type=rss")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://condresos.codelinsoft.it/index.php/blog?format=feed&amp;type=rss"))).toString();
   else if (distro == ectn_ENDEAVOUROS)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://endeavouros.com/feed/")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://endeavouros.com/feed/"))).toString();
   else if (distro == ectn_KAOS)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://kaosx.us/feed.xml")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://kaosx.us/feed.xml"))).toString();
   else if (distro == ectn_MANJAROLINUX)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://forum.manjaro.org/c/announcements.rss")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://forum.manjaro.org/c/announcements.rss"))).toString();
   /*else if (distro == ectn_NETRUNNER)
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://www.netrunner.com/feed/")).toString();*/
   else if (distro == ectn_PARABOLA)
-    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, "https://www.parabola.nu/feeds/news/")).toString();
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://www.parabola.nu/feeds/news/"))).toString();
   else return QLatin1String("");
 }
 
@@ -317,7 +317,7 @@ QString SettingsManager::getAURTool()
   QString params;
 
   SettingsManager p_instance;
-  QString ret = (p_instance.getSYSsettings()->value(ctn_KEY_AUR_TOOL, "")).toString();
+  QString ret = (p_instance.getSYSsettings()->value(ctn_KEY_AUR_TOOL, QLatin1String(""))).toString();
 
   if (ret == ctn_NO_AUR_TOOL) return ret;
   else if (ret == ctn_PACAUR_TOOL)
@@ -440,13 +440,13 @@ bool SettingsManager::getEnableAURVoting()
 QString SettingsManager::getAURUserName()
 {
   SettingsManager p_instance;
-  return (p_instance.getSYSsettings()->value(ctn_KEY_AUR_USERNAME, "")).toString();
+  return (p_instance.getSYSsettings()->value(ctn_KEY_AUR_USERNAME, QLatin1String(""))).toString();
 }
 
 QString SettingsManager::getAURPassword()
 {
   SettingsManager p_instance;
-  QByteArray encryptedValue = (p_instance.getSYSsettings()->value(ctn_KEY_AUR_PASSWORD, "")).toByteArray();
+  QByteArray encryptedValue = (p_instance.getSYSsettings()->value(ctn_KEY_AUR_PASSWORD, QLatin1String(""))).toByteArray();
 
   QString aurUserName = getAURUserName();
   if (aurUserName.isEmpty()) return QLatin1String("");
@@ -456,14 +456,14 @@ QString SettingsManager::getAURPassword()
 
   QAESEncryption encryption(QAESEncryption::AES_256, QAESEncryption::CBC);
   QByteArray decodeText = encryption.decode(encryptedValue, hashKey, hashIV);
-  QString decryptedValue = QString(encryption.removePadding(decodeText));
+  QString decryptedValue = QString::fromUtf8(encryption.removePadding(decodeText));
   return decryptedValue;
 }
 
 QString SettingsManager::getProxySettings()
 {
   SettingsManager p_instance;
-  return (p_instance.getSYSsettings()->value(ctn_KEY_PROXY_SETTINGS, "").toString());
+  return (p_instance.getSYSsettings()->value(ctn_KEY_PROXY_SETTINGS, QLatin1String("")).toString());
 }
 
 bool SettingsManager::getUseAlternateRowColor()
@@ -521,13 +521,13 @@ bool SettingsManager::hasPacmanBackend()
 {
   if (!instance()->getSYSsettings()->contains(ctn_KEY_BACKEND))
   {
-    instance()->getSYSsettings()->setValue(ctn_KEY_BACKEND, "alpm");
+    instance()->getSYSsettings()->setValue(ctn_KEY_BACKEND, QStringLiteral("alpm"));
     return false;
   }
   else
   {
     SettingsManager p_instance;
-    return (p_instance.getSYSsettings()->value(ctn_KEY_BACKEND, "pacman") != "alpm");
+    return (p_instance.getSYSsettings()->value(ctn_KEY_BACKEND, QStringLiteral("pacman")) != QLatin1String("alpm"));
   }
 }
 

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -47,7 +47,7 @@ class SettingsManager
     static QString getOctopiConfPath()
     {
       return QDir::homePath() +
-          QDir::separator() + ".config/octopi/octopi.conf";
+          QDir::separator() + QLatin1String(".config/octopi/octopi.conf");
     }
 
     static int getCurrentTabIndex();

--- a/src/strconstants.cpp
+++ b/src/strconstants.cpp
@@ -22,15 +22,15 @@
 #include "unixcommand.h"
 
 QString StrConstants::getApplicationName(){
-  return "Octopi";
+  return QStringLiteral("Octopi");
 }
 
 QString StrConstants::getApplicationVersion(){
-  return "0.10.0 (dev)";
+  return QStringLiteral("0.10.0 (dev)");
 }
 
 QString StrConstants::getQtVersion(){
-  return "Qt " + QString(QT_VERSION_STR);
+  return "Qt " + QStringLiteral(QT_VERSION_STR);
 }
 
 QString StrConstants::getApplicationCliHelp(){
@@ -54,16 +54,16 @@ QString StrConstants::getAll(){
 
 QString StrConstants::getForeignRepositoryName(){
   static bool firstTime=true;
-  static QString ret=QLatin1String("AUR");
+  static QString ret=QStringLiteral("AUR");
 
   if (firstTime)
   {
     if (UnixCommand::getLinuxDistro() == ectn_CHAKRA)
-      ret=QLatin1String("CCR");
+      ret=QStringLiteral("CCR");
     if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-      ret=QLatin1String("KCP");
+      ret=QStringLiteral("KCP");
     if (UnixCommand::getLinuxDistro() == ectn_PARABOLA)
-      ret=QLatin1String("Custom");
+      ret=QStringLiteral("Custom");
 
     firstTime=false;
   }
@@ -73,16 +73,16 @@ QString StrConstants::getForeignRepositoryName(){
 
 QString StrConstants::getForeignPkgRepositoryName(){
   static bool firstTime=true;
-  static QString ret=QLatin1String("aur");
+  static QString ret=QStringLiteral("aur");
 
   if (firstTime)
   {
     if (UnixCommand::getLinuxDistro() == ectn_CHAKRA)
-      ret=QLatin1String("ccr");
+      ret=QStringLiteral("ccr");
     else if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-      ret=QLatin1String("kcp");
+      ret=QStringLiteral("kcp");
     else if (UnixCommand::getLinuxDistro() == ectn_PARABOLA)
-      ret=QLatin1String("custom");
+      ret=QStringLiteral("custom");
 
     firstTime=false;
   }
@@ -93,16 +93,16 @@ QString StrConstants::getForeignPkgRepositoryName(){
 QString StrConstants::getForeignRepositoryGroupName()
 {
   static bool firstTime=true;
-  static QString ret=QLatin1String("AUR");
+  static QString ret=QStringLiteral("AUR");
 
   if (firstTime)
   {
     if( UnixCommand::getLinuxDistro() == ectn_CHAKRA )
-      ret=QLatin1String("Ccr");
+      ret=QStringLiteral("Ccr");
     else if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-      ret=QLatin1String("KCP");
+      ret=QStringLiteral("KCP");
     else if (UnixCommand::getLinuxDistro() == ectn_PARABOLA)
-      ret=QLatin1String("Custom");
+      ret=QStringLiteral("Custom");
 
     firstTime=false;
   }
@@ -113,16 +113,16 @@ QString StrConstants::getForeignRepositoryGroupName()
 QString StrConstants::getForeignRepositoryTargetPrefix()
 {
   static bool firstTime=true;
-  static QString ret=QLatin1String("aur/");
+  static QString ret=QStringLiteral("aur/");
 
   if (firstTime)
   {
     if( UnixCommand::getLinuxDistro() == ectn_CHAKRA )
-      ret=QLatin1String("ccr/");
+      ret=QStringLiteral("ccr/");
     else if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-      ret=QLatin1String("kcp/");
+      ret=QStringLiteral("kcp/");
     else if (UnixCommand::getLinuxDistro() == ectn_PARABOLA)
-      ret=QLatin1String("custom/");
+      ret=QStringLiteral("custom/");
 
     firstTime=false;
   }
@@ -447,30 +447,30 @@ QString StrConstants::getRemovingPacmanTransactionLockFile(){
 }
 
 QString StrConstants::getSyncing(){
-  return "Syncing";
+  return QStringLiteral("Syncing");
 }
 
 QString StrConstants::getPressAnyKey(){
-  return "Press any key to continue...";
+  return QStringLiteral("Press any key to continue...");
 }
 
 QString StrConstants::getCouldNotAttachToParent()
 {
-  return "octopi-helper[aborted]: Couldn't attach to parent";
+  return QStringLiteral("octopi-helper[aborted]: Couldn't attach to parent");
 }
 
 QString StrConstants::getSuspiciousExecutionDetected()
 {
-  return "octopi-helper[aborted]: Suspicious execution method";
+  return QStringLiteral("octopi-helper[aborted]: Suspicious execution method");
 }
 
 QString StrConstants::getSuspiciousTransactionDetected()
 {
-  return "octopi-helper[aborted]: Suspicious transaction detected ->";
+  return QStringLiteral("octopi-helper[aborted]: Suspicious transaction detected ->");
 }
 
 QString StrConstants::getErrorPacmanProcessExecuting(){
-  return "octopi-helper[aborted]: There is an instance of pacman already running";
+  return QStringLiteral("octopi-helper[aborted]: There is an instance of pacman already running");
 }
 
 QString StrConstants::getCheckUpdates()
@@ -494,7 +494,7 @@ QString StrConstants::getNoUpdatesAvailable()
 }
 
 QString StrConstants::getSyncMirror(){
-  return "Mirror-check...";
+  return QStringLiteral("Mirror-check...");
 }
 
 QString StrConstants::getSyncDatabase(){
@@ -506,7 +506,7 @@ QString StrConstants::getSyncDatabases(){
 }
 
 QString StrConstants::getIsUpToDate(){
-  return "is up to date";
+  return QStringLiteral("is up to date");
 }
 
 QString StrConstants::getSysInfoGenerated()
@@ -646,7 +646,7 @@ QString StrConstants::getYoullNeedSuFrontend(){
 QString StrConstants::getYoullNeedToInstallAURTool()
 {
   return QObject::tr("You'll need one of those tools to use AUR:\n\n"
-                     "%1, %2, %3 %4 or %5").arg("pacaur").arg("pikaur", "trizen", "yaourt", "yay");
+                     "%1, %2, %3 %4 or %5").arg(QStringLiteral("pacaur")).arg("pikaur", "trizen", "yaourt", "yay");
 }
 
 QString StrConstants::getDoYouWantToInstallYayTool()

--- a/src/strconstants.cpp
+++ b/src/strconstants.cpp
@@ -30,15 +30,15 @@ QString StrConstants::getApplicationVersion(){
 }
 
 QString StrConstants::getQtVersion(){
-  return "Qt " + QStringLiteral(QT_VERSION_STR);
+  return QLatin1String("Qt ") + QStringLiteral(QT_VERSION_STR);
 }
 
 QString StrConstants::getApplicationCliHelp(){
- QString str = getApplicationName() + " - " + getApplicationVersion() + "\n" +
-      "\n" + getHelpUsage() + "\n\n" +
-      "\t-version: " + QObject::tr("show application version.") + "\n" +
-      "\t-removecmd <Remove-command>: " + QObject::tr("use a different remove command (ex: -removecmd R).") + "\n" +
-      "\t-sysupgrade: " + QObject::tr("force a system upgrade at startup.") + "\n";
+ QString str = getApplicationName() + QLatin1String(" - ") + getApplicationVersion() + QLatin1String("\n") +
+      QLatin1String("\n") + getHelpUsage() + QLatin1String("\n\n") +
+      QLatin1String("\t-version: ") + QObject::tr("show application version.") + QLatin1String("\n") +
+      QLatin1String("\t-removecmd <Remove-command>: ") + QObject::tr("use a different remove command (ex: -removecmd R).") + QLatin1String("\n") +
+      QLatin1String("\t-sysupgrade: ") + QObject::tr("force a system upgrade at startup.") + QLatin1String("\n");
 
  return str;
 }
@@ -185,9 +185,9 @@ QString StrConstants::getDisplayAllGroups(){
 QString StrConstants::getForeignToolGroup(){
  QString tool = Package::getForeignRepositoryToolName();
   tool[0] = tool[0].toUpper();
-  tool = "<" + tool + ">";
+  tool = QLatin1String("<") + tool + QLatin1String(">");
 
-  return tool.toLatin1();
+  return tool;
 }
 
 QString StrConstants::getHelpUsage(){
@@ -646,7 +646,7 @@ QString StrConstants::getYoullNeedSuFrontend(){
 QString StrConstants::getYoullNeedToInstallAURTool()
 {
   return QObject::tr("You'll need one of those tools to use AUR:\n\n"
-                     "%1, %2, %3 %4 or %5").arg(QStringLiteral("pacaur")).arg("pikaur", "trizen", "yaourt", "yay");
+                     "%1, %2, %3 %4 or %5").arg(QStringLiteral("pacaur")).arg(QStringLiteral("pikaur"), QStringLiteral("trizen"), QStringLiteral("yaourt"), QStringLiteral("yay"));
 }
 
 QString StrConstants::getDoYouWantToInstallYayTool()
@@ -870,45 +870,45 @@ QString StrConstants::getExit()
 //Style Sheets ---------------------------------
 
 QString StrConstants::getToolBarCSS(){
-  return QString("QToolBar { border: 5px; } "
-                 "QToolTip {}");
+  return QString(QStringLiteral("QToolBar { border: 5px; } "
+                 "QToolTip {}"));
 }
 
 QString StrConstants::getFilterPackageNotFoundCSS(){
-  return QString("QLineEdit{ color: white; "
+  return QString(QStringLiteral("QLineEdit{ color: white; "
                  "background-color: rgb(207, 135, 142);"
-                 "border-color: rgb(206, 204, 197);}"
+                 "border-color: rgb(206, 204, 197);}")
                  );
 }
 
 QString StrConstants::getFilterPackageFoundCSS(){
-  return QString("QLineEdit, SearchLineEdit{ color: black; "
+  return QString(QStringLiteral("QLineEdit, SearchLineEdit{ color: black; "
                  "background-color: rgb(255, 255, 200);"
-                 "border-color: rgb(206, 204, 197);}"
+                 "border-color: rgb(206, 204, 197);}")
                  );
 }
 
 QString StrConstants::getDockWidgetTitleCSS(){
-  return QString("QDockWidget::title { "
+  return QString(QStringLiteral("QDockWidget::title { "
                  "text-align: right;"
                  "background: transparent;"
-                 "padding-right: 5px;}"
+                 "padding-right: 5px;}")
                  );
 }
 
 QString StrConstants::getTabBarCSS(){
-  return QString("QTabBar::close-button {"
+  return QString(QStringLiteral("QTabBar::close-button {"
                  "image: url(:/resources/images/window-close.png);"
                  "border-radius: 4px}"
                  "QTabBar::close-button:hover {"
                  "background-color: palette(light)}"
                  "QTabBar::close-button:pressed {"
-                 "background-color: palette(mid)}"
+                 "background-color: palette(mid)}")
                  );
 }
 
 QString StrConstants::getTreeViewCSS(){
-  return QString("QTreeView::branch:has-siblings:!adjoins-item {"
+  return QString(QStringLiteral("QTreeView::branch:has-siblings:!adjoins-item {"
                  "   border-image: url(:/resources/styles/vline.png) 0;}"
                  "QTreeView::branch:has-siblings:adjoins-item {"
                  "    border-image: url(:/resources/styles/branch-more.png) 0;}"
@@ -921,5 +921,5 @@ QString StrConstants::getTreeViewCSS(){
                  "QTreeView::branch:open:has-children:!has-siblings,"
                  "QTreeView::branch:open:has-children:has-siblings  {"
                  "       border-image: none;"
-                 "       image: url(:/resources/styles/branch-open_BW.png);}");
+                 "       image: url(:/resources/styles/branch-open_BW.png);}"));
 }

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -59,7 +59,7 @@ void Terminal::runOctopiHelperInTerminalWithSharedMem(const QStringList &command
 
   foreach(QString line, commandList)
   {
-    if (line.contains("echo -e") || line.contains("read -n 1"))
+    if (line.contains(QLatin1String("echo -e")) || line.contains(QLatin1String("read -n 1")))
     {
       removedLines = true;
       continue;
@@ -137,16 +137,16 @@ void Terminal::runCommandInTerminalAsNormalUser(const QStringList &commandList)
 
   foreach(QString line, commandList)
   {
-    if ((line.contains("echo -e") || line.contains("read -n 1"))) //&& m_selectedTerminal == ctn_QTERMWIDGET)
+    if ((line.contains(QLatin1String("echo -e")) || line.contains(QLatin1String("read -n 1")))) //&& m_selectedTerminal == ctn_QTERMWIDGET)
     {
       removedLines = true;
       continue;
     }
 
     //We must remove the "ccr/" prefix in Chakra, cos this will not work
-    if(line.contains("ccr/"))
+    if(line.contains(QLatin1String("ccr/")))
     {
-      line = line.replace("ccr/", "");
+      line = line.replace(QLatin1String("ccr/"), QLatin1String(""));
     }
 
     out += line;

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -45,7 +45,7 @@ Terminal::~Terminal()
  */
 void Terminal::runCommandInTerminalWithSudo(const QString& command)
 {
-  QString cmd = "sudo " + UnixCommand::getShell() + " -c \"" + command + "\"";
+  QString cmd = QLatin1String("sudo ") + UnixCommand::getShell() + QLatin1String(" -c \"") + command + QLatin1Char('"');
   emit commandToExecInQTermWidget(cmd);
 }
 
@@ -65,14 +65,14 @@ void Terminal::runOctopiHelperInTerminalWithSharedMem(const QStringList &command
       continue;
     }
 
-    out += line + "\n";
+    out += line + QLatin1Char('\n');
   }
 
-  if (removedLines) out += "echo \"" + StrConstants::getPressAnyKey() + "\"";
+  if (removedLines) out += QLatin1String("echo \"") + StrConstants::getPressAnyKey() + QLatin1String("\"");
 
   QString suCommand = WMHelper::getSUCommand();
-  QString commandToRun = ctn_OCTOPI_HELPER_PATH + " -ts";
-  QString cmd = "sudo " + commandToRun;
+  QString commandToRun = ctn_OCTOPI_HELPER_PATH + QLatin1String(" -ts");
+  QString cmd = QLatin1String("sudo ") + commandToRun;
   QByteArray sharedData=out.toLatin1();
 
   /*if (sharedMem != nullptr)
@@ -152,12 +152,12 @@ void Terminal::runCommandInTerminalAsNormalUser(const QStringList &commandList)
     out += line;
   }
 
-  if (removedLines) out += "echo '" + StrConstants::getPressAnyKey() + "'";
+  if (removedLines) out += QLatin1String("echo '") + StrConstants::getPressAnyKey() + QLatin1Char('\'');
 
   //out.flush();
   //ftemp->close();
 
   QString cmd;
-  cmd = UnixCommand::getShell() + " -c \"" + out /*ftemp->fileName()*/ + "\"";
+  cmd = UnixCommand::getShell() + QLatin1String(" -c \"") + out /*ftemp->fileName()*/ + QLatin1Char('"');
   emit commandToExecInQTermWidget(cmd);
 }

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -120,7 +120,7 @@ void TermWidget::parseOutput(QString str)
   //qDebug() << "terminal: " << str << endl;
 
   if ((str == StrConstants::getPressAnyKey() ||
-       str == StrConstants::getPressAnyKey() + "\r\n") ||
+       str == StrConstants::getPressAnyKey() + QLatin1String("\r\n")) ||
       str.contains(StrConstants::getSuspiciousExecutionDetected()) ||
       str.contains(StrConstants::getSuspiciousTransactionDetected()) ||
       str.contains(StrConstants::getCouldNotAttachToParent())

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -37,7 +37,7 @@ TermWidget::TermWidget(QWidget *parent):
   QTermWidget(parent)
 {
   setScrollBarPosition(QTermWidget::ScrollBarRight);
-  setColorScheme("WhiteOnBlack");
+  setColorScheme(QStringLiteral("WhiteOnBlack"));
   setContextMenuPolicy(Qt::CustomContextMenu);
 
   m_actionZoomIn = new QAction(this);
@@ -108,7 +108,7 @@ void TermWidget::execute(QString command)
 void TermWidget::enter()
 {
   //This is the ENTER/RETURN key!
-  QString enter("\r");
+  QString enter(QStringLiteral("\r"));
   this->sendText(enter);
 }
 
@@ -128,8 +128,8 @@ void TermWidget::parseOutput(QString str)
   {
     emit onPressAnyKeyToContinue();
   }
-  else if (str.contains("quit: command not found") ||
-           str.contains("close: command not found"))
+  else if (str.contains(QLatin1String("quit: command not found")) ||
+           str.contains(QLatin1String("close: command not found")))
   {
     emit onKeyQuit();
   }

--- a/src/transactiondialog.cpp
+++ b/src/transactiondialog.cpp
@@ -76,7 +76,7 @@ void TransactionDialog::setDetailedText(const QString &detailedtext)
   ui->detailedText->setText(detailedtext);
 
   //We must search for a 'pacman-version-number' pkg to force terminal upgrade use
-  if (detailedtext.contains(QRegularExpression("pacman-[0-9]+")))
+  if (detailedtext.contains(QRegularExpression(QStringLiteral("pacman-[0-9]+"))))
   {
     removeYesButton();
   }

--- a/src/treeviewpackagesitemdelegate.cpp
+++ b/src/treeviewpackagesitemdelegate.cpp
@@ -45,7 +45,7 @@ TreeViewPackagesItemDelegate::TreeViewPackagesItemDelegate(QObject *parent):
 bool TreeViewPackagesItemDelegate::helpEvent ( QHelpEvent *event, QAbstractItemView*,
     const QStyleOptionViewItem&, const QModelIndex &index )
 {
-  if (this->parent()->objectName() == "tvPackages")
+  if (this->parent()->objectName() == QLatin1String("tvPackages"))
   {
     QTreeView* tvPackages = qobject_cast<QTreeView*>(this->parent());
     PackageModel* sim = qobject_cast<PackageModel*>(tvPackages->model());
@@ -64,7 +64,7 @@ bool TreeViewPackagesItemDelegate::helpEvent ( QHelpEvent *event, QAbstractItemV
     }
     else return false;
   }
-  else if (this->parent()->objectName() == "tvTransaction")
+  else if (this->parent()->objectName() == QLatin1String("tvTransaction"))
   {
     QTreeView* tvTransaction = qobject_cast<QTreeView*>(this->parent());
     QStandardItemModel *sim = qobject_cast<QStandardItemModel*>(tvTransaction->model());
@@ -79,7 +79,7 @@ bool TreeViewPackagesItemDelegate::helpEvent ( QHelpEvent *event, QAbstractItemV
       QString pkgName=si->text();
 
       //We have to separate Repository from Package Name, first
-      int slash = pkgName.indexOf("/");
+      int slash = pkgName.indexOf(QLatin1String("/"));
       if (slash != -1)
       {
         pkgName = pkgName.mid(slash+1);

--- a/src/ui/octopitabinfo.cpp
+++ b/src/ui/octopitabinfo.cpp
@@ -32,7 +32,7 @@
 /**
  * @brief OctopiTabInfo::anchorBegin for navigation
  */
-const QString OctopiTabInfo::anchorBegin("anchorBegin");
+const QString OctopiTabInfo::anchorBegin(QStringLiteral("anchorBegin"));
 
 OctopiTabInfo::OctopiTabInfo()
 {
@@ -76,24 +76,24 @@ QString OctopiTabInfo::formatTabInfo(const PackageRepository::PackageData& packa
   //Let's put package description in UTF-8 format
   QString pkgDescription = pid.description;
   QString html;
-  html += "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
-  html += "<a id=\"" + anchorBegin + "\"></a>";
+  html += QLatin1String("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">");
+  html += QLatin1String("<a id=\"") + anchorBegin + QLatin1String("\"></a>");
 
   if (package.repository != StrConstants::getForeignRepositoryName())
   {
-    html += "<h2>" + package.name + "</h2>";
+    html += QLatin1String("<h2>") + package.name + QLatin1String("</h2>");
   }
   else if (UnixCommand::getLinuxDistro() == ectn_KAOS || UnixCommand::getLinuxDistro() == ectn_CHAKRA)
-    html += "<h2>" + package.name + "</h2>";
+    html += QLatin1String("<h2>") + package.name + QLatin1String("</h2>");
   else
-    html += "<h2><a href=\"https://aur.archlinux.org/packages/" + package.name + "\">" + package.name + "</a></h2>";
+    html += QLatin1String("<h2><a href=\"https://aur.archlinux.org/packages/") + package.name + QLatin1String("\">") + package.name + QLatin1String("</a></h2>");
 
   html += pkgDescription;
 
-  html += "<table border=\"0\">";
+  html += QLatin1String("<table border=\"0\">");
 
-  html += "<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>";
-  html += "<tr><td>" + url + "</td><td>" + pid.url + "</td></tr>";
+  html += QLatin1String("<tr><th width=\"20%\"></th><th width=\"80%\"></th></tr>");
+  html += QLatin1String("<tr><td>") + url + QLatin1String("</td><td>") + pid.url + QLatin1String("</td></tr>");
 
   if (package.outdated())
   {
@@ -102,9 +102,9 @@ QString OctopiTabInfo::formatTabInfo(const PackageRepository::PackageData& packa
       if (package.status == ectn_OUTDATED)
       {
         QString outdatedVersion = package.outdatedVersion;
-        html += "<tr><td>" + version + "</td><td>" + package.version + " <b><font color=\"#E55451\">"
+        html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + package.version + QLatin1String(" <b><font color=\"#E55451\">")
             + StrConstants::getOutdatedInstalledVersion().arg(outdatedVersion) +
-            "</b></font></td></tr>";
+            QLatin1String("</b></font></td></tr>");
       }
       else if (package.status == ectn_FOREIGN_OUTDATED && //NEW ELSE
           outdatedAURPackagesNameVersion.count() > 0)
@@ -114,24 +114,24 @@ QString OctopiTabInfo::formatTabInfo(const PackageRepository::PackageData& packa
         QString availableVersion = outdatedAURPackagesNameVersion.value(package.name);
         if (availableVersion.isEmpty()) availableVersion = package.version;
 
-        html += "<tr><td>" + version + "</td><td>" + availableVersion + " <b><font color=\"#E55451\">"
+        html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + availableVersion + QLatin1String(" <b><font color=\"#E55451\">")
             + StrConstants::getOutdatedInstalledVersion().arg(outdatedVersion) +
-            "</b></font></td></tr>";
+            QLatin1String("</b></font></td></tr>");
       }
     }
     else
     {
       QString newerVersion = package.outdatedVersion;
-      html += "<tr><td>" + version + "</td><td>" + package.version + " <b><font color=\"#FF8040\">"
+      html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + package.version + QLatin1String(" <b><font color=\"#FF8040\">")
           + StrConstants::getNewerInstalledVersion().arg(newerVersion) +
-          "</b></font></td></tr>";
+          QLatin1String("</b></font></td></tr>");
     }
   }
   else //Is this Else needed?
   {
     if (package.repository != StrConstants::getForeignRepositoryName())
     {
-      html += "<tr><td>" + version + "</td><td>" + package.version + "</td></tr>";
+      html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + package.version + QLatin1String("</td></tr>");
     }
     else
     {
@@ -143,69 +143,69 @@ QString OctopiTabInfo::formatTabInfo(const PackageRepository::PackageData& packa
         QString availableVersion = outdatedAURPackagesNameVersion.value(package.name);
         if (availableVersion.isEmpty()) availableVersion = package.version;
 
-        html += "<tr><td>" + version + "</td><td>" + availableVersion + " <b><font color=\"#E55451\">"
+        html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + availableVersion + QLatin1String(" <b><font color=\"#E55451\">")
             + StrConstants::getOutdatedInstalledVersion().arg(outdatedVersion) +
-            "</b></font></td></tr>";
+            QLatin1String("</b></font></td></tr>");
       }
       else
       {
-        html += "<tr><td>" + version + "</td><td>" + package.version + "</td></tr>";
+        html += QLatin1String("<tr><td>") + version + QLatin1String("</td><td>") + package.version + QLatin1String("</td></tr>");
       }
     }
   }
 
   //This is needed as packager names could be encoded in different charsets, resulting in an error
   QString packagerName = pid.packager;
-  packagerName = packagerName.replace("<", "&lt;");
-  packagerName = packagerName.replace(">", "&gt;");
+  packagerName = packagerName.replace(QLatin1String("<"), QLatin1String("&lt;"));
+  packagerName = packagerName.replace(QLatin1String(">"), QLatin1String("&gt;"));
 
   QString strConflictsWith = pid.conflictsWith;
-  strConflictsWith = strConflictsWith.replace("<", "&lt;");
-  strConflictsWith = strConflictsWith.replace(">", "&gt;");
-  strConflictsWith = strConflictsWith.replace("&lt;br&gt;", "<br>");
+  strConflictsWith = strConflictsWith.replace(QLatin1String("<"), QLatin1String("&lt;"));
+  strConflictsWith = strConflictsWith.replace(QLatin1String(">"), QLatin1String("&gt;"));
+  strConflictsWith = strConflictsWith.replace(QLatin1String("&lt;br&gt;"), QLatin1String("<br>"));
 
-  html += "<tr><td>" + licenses + "</td><td>" + pid.license + "</td></tr>";
+  html += QLatin1String("<tr><td>") + licenses + QLatin1String("</td><td>") + pid.license + QLatin1String("</td></tr>");
 
   //Show this info only if there's something to show
-  if(! pid.group.contains("None"))
-    html += "<tr><td>" + groups + "</td><td>" + pid.group + "</td></tr>";
+  if(! pid.group.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + groups + QLatin1String("</td><td>") + pid.group + QLatin1String("</td></tr>");
 
-  if(! pid.provides.contains("None"))
-    html += "<tr><td>" + provides + "</td><td>" + Package::makeAnchorOfPackage(pid.provides) + "</td></tr>";
+  if(! pid.provides.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + provides + QLatin1String("</td><td>") + Package::makeAnchorOfPackage(pid.provides) + QLatin1String("</td></tr>");
 
-  if(! pid.dependsOn.contains("None"))
-    html += "<tr><td>" + dependsOn + "</td><td>" + Package::makeAnchorOfPackage(pid.dependsOn) + "</td></tr>";
+  if(! pid.dependsOn.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + dependsOn + QLatin1String("</td><td>") + Package::makeAnchorOfPackage(pid.dependsOn) + QLatin1String("</td></tr>");
 
-  if(! pid.optDepends.contains("None"))
-    html += "<tr><td>" + optionalDeps + "</td><td>" + Package::makeAnchorOfOptionalDep(pid.optDepends) + "</td></tr>";
+  if(! pid.optDepends.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + optionalDeps + QLatin1String("</td><td>") + Package::makeAnchorOfOptionalDep(pid.optDepends) + QLatin1String("</td></tr>");
 
-  if(!pid.requiredBy.isEmpty() && !pid.requiredBy.contains("None"))
-    html += "<tr><td>" + requiredBy + "</td><td>" + Package::makeAnchorOfPackage(pid.requiredBy) + "</td></tr>";
+  if(!pid.requiredBy.isEmpty() && !pid.requiredBy.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + requiredBy + QLatin1String("</td><td>") + Package::makeAnchorOfPackage(pid.requiredBy) + QLatin1String("</td></tr>");
 
-  if(!pid.optionalFor.isEmpty() && !pid.optionalFor.contains("None"))
-    html += "<tr><td>" + optionalFor + "</td><td>" + Package::makeAnchorOfPackage(pid.optionalFor) + "</td></tr>";
+  if(!pid.optionalFor.isEmpty() && !pid.optionalFor.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + optionalFor + QLatin1String("</td><td>") + Package::makeAnchorOfPackage(pid.optionalFor) + QLatin1String("</td></tr>");
 
-  if(! pid.conflictsWith.contains("None"))
-    html += "<tr><td><b>" + conflictsWith + "</b></td><td><b>" + Package::makeAnchorOfPackage(strConflictsWith) +
-        "</b></font></td></tr>";
+  if(! pid.conflictsWith.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td><b>") + conflictsWith + QLatin1String("</b></td><td><b>") + Package::makeAnchorOfPackage(strConflictsWith) +
+        QLatin1String("</b></font></td></tr>");
 
-  if(! pid.replaces.contains("None"))
-    html += "<tr><td>" + replaces + "</td><td>" + Package::makeAnchorOfPackage(pid.replaces) + "</td></tr>";
+  if(! pid.replaces.contains(QLatin1String("None")))
+    html += QLatin1String("<tr><td>") + replaces + QLatin1String("</td><td>") + Package::makeAnchorOfPackage(pid.replaces) + QLatin1String("</td></tr>");
 
-  html += "<tr><td>" + downloadSize + "</td><td>" + Package::kbytesToSize(pid.downloadSize) + "</td></tr>";
-  html += "<tr><td>" + installedSize + "</td><td>" + Package::kbytesToSize(pid.installedSize) + "</td></tr>";
-  html += "<tr><td>" + packager + "</td><td>" + packagerName + "</td></tr>";
-  html += "<tr><td>" + architecture + "</td><td>" + pid.arch + "</td></tr>";
+  html += QLatin1String("<tr><td>") + downloadSize + QLatin1String("</td><td>") + Package::kbytesToSize(pid.downloadSize) + QLatin1String("</td></tr>");
+  html += QLatin1String("<tr><td>") + installedSize + QLatin1String("</td><td>") + Package::kbytesToSize(pid.installedSize) + QLatin1String("</td></tr>");
+  html += QLatin1String("<tr><td>") + packager + QLatin1String("</td><td>") + packagerName + QLatin1String("</td></tr>");
+  html += QLatin1String("<tr><td>") + architecture + QLatin1String("</td><td>") + pid.arch + QLatin1String("</td></tr>");
 
   QString dateTimeFormat = QLocale().dateTimeFormat();
 
-  html += "<tr><td>" + buildDate + "</td><td>" +
-      pid.buildDate.toString(dateTimeFormat) + "</td></tr>";
+  html += QLatin1String("<tr><td>") + buildDate + QLatin1String("</td><td>") +
+      pid.buildDate.toString(dateTimeFormat) + QLatin1String("</td></tr>");
 
   if(!pid.installReason.isEmpty())
-    html += "<tr><td>" + installReason + "</td><td>" + pid.installReason + "</td></tr>";
+    html += QLatin1String("<tr><td>") + installReason + QLatin1String("</td><td>") + pid.installReason + QLatin1String("</td></tr>");
 
-  html += "</table><br>";
+  html += QLatin1String("</table><br>");
 
   return html;
 }

--- a/src/uihelper.h
+++ b/src/uihelper.h
@@ -82,25 +82,25 @@ public:
     {
       case ectn_OCTOPI_BUSY:
         if (useDefaultIcons)
-          res = ":/resources/images/octopi_transparent.png";
+          res = QStringLiteral(":/resources/images/octopi_transparent.png");
         else
           res = SettingsManager::getOctopiBusyIconPath();
         break;
       case ectn_OCTOPI_RED:
         if (useDefaultIcons)
-          res = ":/resources/images/octopi_red.png";
+          res = QStringLiteral(":/resources/images/octopi_red.png");
         else
           res = SettingsManager::getOctopiRedIconPath();
         break;
       case ectn_OCTOPI_YELLOW:
         if (useDefaultIcons)
-          res = ":/resources/images/octopi_yellow.png";
+          res = QStringLiteral(":/resources/images/octopi_yellow.png");
         else
           res = SettingsManager::getOctopiYellowIconPath();
         break;
       case ectn_OCTOPI_GREEN:
         if (useDefaultIcons)
-          res = ":/resources/images/octopi_green.png";
+          res = QStringLiteral(":/resources/images/octopi_green.png");
         else
           res = SettingsManager::getOctopiGreenIconPath();
     }

--- a/src/uihelper.h
+++ b/src/uihelper.h
@@ -110,7 +110,7 @@ public:
 
   static QIcon getIconOctopi(){
     if (WMHelper::isKDERunning())
-      return QIcon::fromTheme("octopi", QIcon());
+      return QIcon::fromTheme(QStringLiteral("octopi"), QIcon());
     else return QIcon();
   }
 
@@ -123,199 +123,199 @@ public:
   static QIcon getIconOctopiGreen(){ return QIcon(getOctopiIconPath(ectn_OCTOPI_GREEN)); }
   //App icon code
 
-  static QIcon getIconFrozen(){ return QIcon(":/resources/images/tgz_frozen_flat.png"); }
-  static QIcon getIconUnFrozen(){ return QIcon(":/resources/images/tgz4_flat.png"); }
-  static QIcon getIconRPM(){ return QIcon(":/resources/images/rpm.png"); }
-  static QIcon getIconInferior(){ return QIcon(":/resources/images/inferiorversion_red.png"); }
-  static QIcon getIconSuperior(){ return QIcon(":/resources/images/superiorversion.png"); }
-  static QIcon getIconOtherVersion(){ return QIcon(":/resources/images/agent.png"); }
-  static QIcon getIconOtherArch(){ return QIcon(":/resources/images/cpu.png"); }
-  static QIcon getIconInstalled(){ return QIcon(":/resources/images/installed.png"); }
-  static QIcon getIconNonInstalled(){ return QIcon(":/resources/images/noninstalled.png"); }
-  static QIcon getIconOutdated(){ return QIcon(":/resources/images/outdated.png"); }
-  static QIcon getIconNewer(){ return QIcon(":/resources/images/newer.png"); }
-  static QIcon getIconUnrequired(){ return QIcon(":/resources/images/unrequired.png"); }
-  static QIcon getIconForeignGreen(){ return QIcon(":/resources/images/foreign_green.png"); }
-  static QIcon getIconForeignRed(){ return QIcon(":/resources/images/foreign_red.png"); }
-  static QIcon getIconForeignWhite(){ return QIcon(":/resources/images/foreign_white.png"); }
-  static QIcon getIconStop(){ return QIcon(":/resources/images/stop_small_red.png"); }
-  static QIcon getIconVote(){ return QIcon(":/resources/images/vote.png"); }
-  static QIcon getIconUnvote(){ return QIcon(":/resources/images/un_vote.png"); }
+  static QIcon getIconFrozen(){ return QIcon(QStringLiteral(":/resources/images/tgz_frozen_flat.png")); }
+  static QIcon getIconUnFrozen(){ return QIcon(QStringLiteral(":/resources/images/tgz4_flat.png")); }
+  static QIcon getIconRPM(){ return QIcon(QStringLiteral(":/resources/images/rpm.png")); }
+  static QIcon getIconInferior(){ return QIcon(QStringLiteral(":/resources/images/inferiorversion_red.png")); }
+  static QIcon getIconSuperior(){ return QIcon(QStringLiteral(":/resources/images/superiorversion.png")); }
+  static QIcon getIconOtherVersion(){ return QIcon(QStringLiteral(":/resources/images/agent.png")); }
+  static QIcon getIconOtherArch(){ return QIcon(QStringLiteral(":/resources/images/cpu.png")); }
+  static QIcon getIconInstalled(){ return QIcon(QStringLiteral(":/resources/images/installed.png")); }
+  static QIcon getIconNonInstalled(){ return QIcon(QStringLiteral(":/resources/images/noninstalled.png")); }
+  static QIcon getIconOutdated(){ return QIcon(QStringLiteral(":/resources/images/outdated.png")); }
+  static QIcon getIconNewer(){ return QIcon(QStringLiteral(":/resources/images/newer.png")); }
+  static QIcon getIconUnrequired(){ return QIcon(QStringLiteral(":/resources/images/unrequired.png")); }
+  static QIcon getIconForeignGreen(){ return QIcon(QStringLiteral(":/resources/images/foreign_green.png")); }
+  static QIcon getIconForeignRed(){ return QIcon(QStringLiteral(":/resources/images/foreign_red.png")); }
+  static QIcon getIconForeignWhite(){ return QIcon(QStringLiteral(":/resources/images/foreign_white.png")); }
+  static QIcon getIconStop(){ return QIcon(QStringLiteral(":/resources/images/stop_small_red.png")); }
+  static QIcon getIconVote(){ return QIcon(QStringLiteral(":/resources/images/vote.png")); }
+  static QIcon getIconUnvote(){ return QIcon(QStringLiteral(":/resources/images/un_vote.png")); }
 
   static QIcon getIconBinary(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("application-x-object",QIcon(":/resources/images/binary.png"));
+      return QIcon::fromTheme(QStringLiteral("application-x-object"),QIcon(QStringLiteral(":/resources/images/binary.png")));
     else
-      return QIcon(":/resources/images/binary.png");
+      return QIcon(QStringLiteral(":/resources/images/binary.png"));
   }
 
   static QIcon getIconToRemove(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("dialog-cancel", QIcon(":/resources/images/toremove.png"));
+      return QIcon::fromTheme(QStringLiteral("dialog-cancel"), QIcon(QStringLiteral(":/resources/images/toremove.png")));
     else
-      return QIcon(":/resources/images/toremove.png");
+      return QIcon(QStringLiteral(":/resources/images/toremove.png"));
   }
 
   static QIcon getIconToInstall(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("download", QIcon(":/resources/images/toinstall.png"));
+      return QIcon::fromTheme(QStringLiteral("download"), QIcon(QStringLiteral(":/resources/images/toinstall.png")));
     else
-      return QIcon(":/resources/images/toinstall.png");
+      return QIcon(QStringLiteral(":/resources/images/toinstall.png"));
   }
 
   static QIcon getIconTerminal(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("utilities-terminal", QIcon(":/resources/images/terminal.png"));
+      return QIcon::fromTheme(QStringLiteral("utilities-terminal"), QIcon(QStringLiteral(":/resources/images/terminal.png")));
     else
-      return QIcon(":/resources/images/terminal.png");
+      return QIcon(QStringLiteral(":/resources/images/terminal.png"));
   }
 
   static QIcon getIconRemoveItem() {
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("list-remove", QIcon(":/resources/images/toremove.png"));
+      return QIcon::fromTheme(QStringLiteral("list-remove"), QIcon(QStringLiteral(":/resources/images/toremove.png")));
     else
-      return QIcon(":/resources/images/toremove.png");
+      return QIcon(QStringLiteral(":/resources/images/toremove.png"));
   }
 
   static QIcon getIconInstallItem() {
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("list-add", QIcon(":/resources/images/toinstall.png"));
+      return QIcon::fromTheme(QStringLiteral("list-add"), QIcon(QStringLiteral(":/resources/images/toinstall.png")));
     else
-      return QIcon(":/resources/images/toinstall.png");
+      return QIcon(QStringLiteral(":/resources/images/toinstall.png"));
   }
 
   static QIcon getIconExit(){    
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("application-exit", QIcon(":/resources/images/exit.png"));
+      return QIcon::fromTheme(QStringLiteral("application-exit"), QIcon(QStringLiteral(":/resources/images/exit.png")));
     else      
-      return QIcon(":/resources/images/exit.png");
+      return QIcon(QStringLiteral(":/resources/images/exit.png"));
   }
 
   // Icons for QActions
   static QIcon getIconCheckUpdates(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("view-refresh", QIcon(":/resources/images/refresh.png"));
+      return QIcon::fromTheme(QStringLiteral("view-refresh"), QIcon(QStringLiteral(":/resources/images/refresh.png")));
     else
-      return QIcon(":/resources/images/refresh.png");
+      return QIcon(QStringLiteral(":/resources/images/refresh.png"));
   }
 
   static QIcon getIconCommit(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("dialog-ok-apply", QIcon(":/resources/images/commit.png"));
+      return QIcon::fromTheme(QStringLiteral("dialog-ok-apply"), QIcon(QStringLiteral(":/resources/images/commit.png")));
     else
-      return QIcon(":/resources/images/commit.png");
+      return QIcon(QStringLiteral(":/resources/images/commit.png"));
   }
 
   static QIcon getIconRollback(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("edit-undo", QIcon(":/resources/images/rollback.png"));
+      return QIcon::fromTheme(QStringLiteral("edit-undo"), QIcon(QStringLiteral(":/resources/images/rollback.png")));
     else
-      return QIcon(":/resources/images/rollback.png");
+      return QIcon(QStringLiteral(":/resources/images/rollback.png"));
   }
 
   static QIcon getIconSystemUpgrade(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("go-up", QIcon(":/resources/images/fast_forward.png"));
+      return QIcon::fromTheme(QStringLiteral("go-up"), QIcon(QStringLiteral(":/resources/images/fast_forward.png")));
     else
-      return QIcon(":/resources/images/fast_forward.png");
+      return QIcon(QStringLiteral(":/resources/images/fast_forward.png"));
   }
 
   static QIcon getIconGetNews(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("application-rss+xml", QIcon(":/resources/images/rss.png"));
+      return QIcon::fromTheme(QStringLiteral("application-rss+xml"), QIcon(QStringLiteral(":/resources/images/rss.png")));
     else
-      return QIcon(":/resources/images/rss.png");
+      return QIcon(QStringLiteral(":/resources/images/rss.png"));
   }
 
   static QIcon getIconCollapse(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("zoom-out", QIcon(":/resources/images/collapse.png"));
+      return QIcon::fromTheme(QStringLiteral("zoom-out"), QIcon(QStringLiteral(":/resources/images/collapse.png")));
     else
-      return QIcon(":/resources/images/collapse.png");
+      return QIcon(QStringLiteral(":/resources/images/collapse.png"));
   }
 
   static QIcon getIconExpand(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("zoom-in", QIcon(":/resources/images/expand.png"));
+      return QIcon::fromTheme(QStringLiteral("zoom-in"), QIcon(QStringLiteral(":/resources/images/expand.png")));
     else
-      return QIcon(":/resources/images/expand.png");
+      return QIcon(QStringLiteral(":/resources/images/expand.png"));
   }
 
   static QIcon getIconEditFile(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("document-edit", QIcon(":/resources/images/editfile.png"));
+      return QIcon::fromTheme(QStringLiteral("document-edit"), QIcon(QStringLiteral(":/resources/images/editfile.png")));
     else
-      return QIcon(":/resources/images/editfile.png");
+      return QIcon(QStringLiteral(":/resources/images/editfile.png"));
   }
 
   static QIcon getIconEditCopy(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("edit-copy", QIcon(":/resources/images/edit-copy.png"));
+      return QIcon::fromTheme(QStringLiteral("edit-copy"), QIcon(QStringLiteral(":/resources/images/edit-copy.png")));
     else
-      return QIcon(":/resources/images/edit-copy.png");
+      return QIcon(QStringLiteral(":/resources/images/edit-copy.png"));
   }
 
   static QIcon getIconFolder(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("document-open-folder", QIcon(":/resources/images/folder.png"));
+      return QIcon::fromTheme(QStringLiteral("document-open-folder"), QIcon(QStringLiteral(":/resources/images/folder.png")));
     else
     {
       if (WMHelper::isKDERunning() || WMHelper::isLuminaRunning() || WMHelper::isLXQTRunning())
       {
-        return QIcon(":/resources/images/folder.png");
+        return QIcon(QStringLiteral(":/resources/images/folder.png"));
       }
       else
       {
-        return QIcon(":/resources/images/folder_gnome.png");
+        return QIcon(QStringLiteral(":/resources/images/folder_gnome.png"));
       }
     }
   }
 
   static QIcon getIconFindFileInPackage(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("edit-find", QIcon(":/resources/images/find.png"));
+      return QIcon::fromTheme(QStringLiteral("edit-find"), QIcon(QStringLiteral(":/resources/images/find.png")));
     else
-      return QIcon(":/resources/images/find.png");
+      return QIcon(QStringLiteral(":/resources/images/find.png"));
   }
 
   static QIcon getIconMirrorCheck(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("svn-update", QIcon(":/resources/images/mirror-check.png"));
+      return QIcon::fromTheme(QStringLiteral("svn-update"), QIcon(QStringLiteral(":/resources/images/mirror-check.png")));
     else
-      return QIcon(":/resources/images/mirror-check.png");
+      return QIcon(QStringLiteral(":/resources/images/mirror-check.png"));
   }
 
   static QIcon getIconShowGroups(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("view-list-tree", QIcon(":/resources/images/show_groups.png"));
+      return QIcon::fromTheme(QStringLiteral("view-list-tree"), QIcon(QStringLiteral(":/resources/images/show_groups.png")));
     else
-      return QIcon(":/resources/images/show_groups.png");
+      return QIcon(QStringLiteral(":/resources/images/show_groups.png"));
   }
 
   static QIcon getIconClose(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("edit-delete", QIcon(":/resources/images/window_close.png"));
+      return QIcon::fromTheme(QStringLiteral("edit-delete"), QIcon(QStringLiteral(":/resources/images/window_close.png")));
     else
-      return QIcon(":/resources/images/window_close.png");
+      return QIcon(QStringLiteral(":/resources/images/window_close.png"));
   }
 
   static QIcon getIconSearch(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("edit-find", QIcon(":/resources/images/esf-search.png"));
+      return QIcon::fromTheme(QStringLiteral("edit-find"), QIcon(QStringLiteral(":/resources/images/esf-search.png")));
     else
-      return QIcon(":/resources/images/esf-search.png");
+      return QIcon(QStringLiteral(":/resources/images/esf-search.png"));
   }
 
   static QIcon getIconClear(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("edit-clear-locationbar-ltr", QIcon(":/resources/images/esf-clear.png"));
+      return QIcon::fromTheme(QStringLiteral("edit-clear-locationbar-ltr"), QIcon(QStringLiteral(":/resources/images/esf-clear.png")));
     else
-      return QIcon(":/resources/images/esf-clear.png");
+      return QIcon(QStringLiteral(":/resources/images/esf-clear.png"));
   }
 
   static QIcon getIconOptions(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("settings-configure", QIcon());
+      return QIcon::fromTheme(QStringLiteral("settings-configure"), QIcon());
     else
       return QIcon();
   }
@@ -323,13 +323,13 @@ public:
   //QActions without icons in Octopi does this works for gtk, too?
   static QIcon getIconHelpAbout(){
     if (WMHelper::isKDERunning() && (UnixCommand::getLinuxDistro() != ectn_KAOS))
-      return QIcon::fromTheme("help-about", QIcon());
+      return QIcon::fromTheme(QStringLiteral("help-about"), QIcon());
     else
       return QIcon();
   }
 
-  static QIcon getIconHelpUsage(){ return QIcon::fromTheme("help-contents"); }
-  static QIcon getIconInstallLocalPackage(){ return QIcon::fromTheme("utilities-file-archiver"); }
+  static QIcon getIconHelpUsage(){ return QIcon::fromTheme(QStringLiteral("help-contents")); }
+  static QIcon getIconInstallLocalPackage(){ return QIcon::fromTheme(QStringLiteral("utilities-file-archiver")); }
 };
 
 //This is a RAII class used when the GUI is going to face a very CPU intensive action

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -48,8 +48,8 @@ UnixCommand::UnixCommand(QObject *parent): QObject()
   m_terminal = new Terminal(parent);
 
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   m_process->setProcessEnvironment(env);
 
   QObject::connect(m_process, SIGNAL( started() ), this,
@@ -89,10 +89,10 @@ QString UnixCommand::runCommand(const QString& commandToRun)
 {
   QProcess proc;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.remove("LANG");
-  env.remove("LC_MESSAGES");
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.remove(QStringLiteral("LANG"));
+  env.remove(QStringLiteral("LC_MESSAGES"));
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   proc.setProcessEnvironment(env);
   proc.start(commandToRun);
   proc.waitForStarted();
@@ -110,14 +110,14 @@ QString UnixCommand::runCommand(const QString& commandToRun)
 QString UnixCommand::runCurlCommand(const QString& commandToRun){
   QProcess proc;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   proc.setProcessEnvironment(env);
   proc.start(commandToRun);
   proc.waitForStarted();
   proc.waitForFinished(-1);
 
-  QString res("");
+  QString res(QLatin1String(""));
 
   if (proc.exitCode() != 0)
   {
@@ -134,8 +134,8 @@ QString UnixCommand::runCurlCommand(const QString& commandToRun){
 QString UnixCommand::discoverBinaryPath(const QString& binary){
   QProcess proc;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   proc.setProcessEnvironment(env);
 
   proc.start("/bin/sh -c \"which " + binary + "\"");
@@ -163,7 +163,7 @@ QString UnixCommand::discoverBinaryPath(const QString& binary){
 bool UnixCommand::cleanPacmanCache()
 {
   QProcess pacman;
-  QString commandStr = "\"yes | pacman -Scc\"";
+  QString commandStr = QStringLiteral("\"yes | pacman -Scc\"");
   QString command = WMHelper::getSUCommand() + " " + commandStr;
   pacman.start(command);
   pacman.waitForFinished();
@@ -179,12 +179,12 @@ QByteArray UnixCommand::performQuery(const QStringList &args)
   QByteArray result("");
   QProcess pacman;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.insert("LC_ALL", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_ALL"), QStringLiteral("C"));
   pacman.setProcessEnvironment(env);
 
-  pacman.start("pacman", args);
+  pacman.start(QStringLiteral("pacman"), args);
   pacman.waitForFinished();
   result = pacman.readAllStandardOutput();
   pacman.close();
@@ -202,9 +202,9 @@ QByteArray UnixCommand::performQuery(const QString &args)
   QProcess pacman;
 
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.insert("LC_ALL", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_ALL"), QStringLiteral("C"));
   pacman.setProcessEnvironment(env);
 
   pacman.start("pacman " + args);
@@ -222,8 +222,8 @@ QByteArray UnixCommand::performAURCommand(const QString &args)
   QByteArray result("");
   QProcess aur;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   aur.setProcessEnvironment(env);
 
   aur.start(Package::getForeignRepositoryToolNameParam() + " " + args);
@@ -251,8 +251,8 @@ QByteArray UnixCommand::getAURUrl(const QString &pkgName)
   QByteArray result("");
   QProcess aur;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
 
   aur.setProcessEnvironment(env);
 
@@ -274,9 +274,9 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
   QByteArray result("");
   QProcess aur;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.insert("LANGUAGE", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LANGUAGE"), QStringLiteral("C"));
 
   aur.setProcessEnvironment(env);
 
@@ -303,11 +303,11 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
   {
     QString res = result;
     res.remove("\033");
-    res.remove("[1m");
-    res.remove("[m");
-    res.remove("[1;32m");
-    res.remove("[1;34m");
-    res.remove("[1;36m");
+    res.remove(QStringLiteral("[1m"));
+    res.remove(QStringLiteral("[m"));
+    res.remove(QStringLiteral("[1;32m"));
+    res.remove(QStringLiteral("[1;34m"));
+    res.remove(QStringLiteral("[1;36m"));
 
     return res.toLatin1();
   }
@@ -315,11 +315,11 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
   {
     QString res = result;
     res.remove("\033");
-    res.remove("[0m");
-    res.remove("[1m");
-    res.remove("[m");
-    res.remove("[32m");
-    res.remove("[35m");
+    res.remove(QStringLiteral("[0m"));
+    res.remove(QStringLiteral("[1m"));
+    res.remove(QStringLiteral("[m"));
+    res.remove(QStringLiteral("[32m"));
+    res.remove(QStringLiteral("[35m"));
 
     return res.toLatin1();
   }
@@ -333,12 +333,12 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
 QString UnixCommand::getShell()
 {
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  QString shell = env.value("SHELL", "/bin/bash");
+  QString shell = env.value(QStringLiteral("SHELL"), QStringLiteral("/bin/bash"));
 
   QFileInfo fi(shell);
 
-  if (fi.fileName() == "fish")
-    return "bash";
+  if (fi.fileName() == QLatin1String("fish"))
+    return QStringLiteral("bash");
   else
     return fi.fileName();
 }
@@ -348,7 +348,7 @@ QString UnixCommand::getShell()
  */
 QByteArray UnixCommand::getUnrequiredPackageList()
 {
-  QByteArray result = performQuery(QStringList("-Qt"));
+  QByteArray result = performQuery(QStringList(QStringLiteral("-Qt")));
   return result;
 }
 
@@ -357,7 +357,7 @@ QByteArray UnixCommand::getUnrequiredPackageList()
  */
 QByteArray UnixCommand::getOutdatedPackageList()
 {
-  return performQuery(QStringList("-Qu"));
+  return performQuery(QStringList(QStringLiteral("-Qu")));
 }
 
 /*
@@ -369,11 +369,11 @@ QByteArray UnixCommand::getOutdatedAURPackageList()
 
   if (Package::getForeignRepositoryToolName() == ctn_KCP_TOOL)
   {
-    result = performAURCommand("-lO");
+    result = performAURCommand(QStringLiteral("-lO"));
   }
   else if (Package::getForeignRepositoryToolName() != ctn_KCP_TOOL)
   {
-    result = performAURCommand("-Qua");
+    result = performAURCommand(QStringLiteral("-Qua"));
   }
 
   //return ":: aur  micro-git  v1.3.3.d6ccaf0-1  ->  v1.3.4\n";
@@ -386,7 +386,7 @@ QByteArray UnixCommand::getOutdatedAURPackageList()
  */
 QByteArray UnixCommand::getForeignPackageList()
 {
-  QByteArray result = performQuery(QStringList("-Qem"));
+  QByteArray result = performQuery(QStringList(QStringLiteral("-Qem")));
   return result;
 }
 
@@ -401,11 +401,11 @@ QByteArray UnixCommand::getPackageList(const QString &pkgName)
   QByteArray result;
 
   if (pkgName.isEmpty())
-    result = performQuery(QStringList("-Ss"));
+    result = performQuery(QStringList(QStringLiteral("-Ss")));
   else
   {
     QStringList sl;
-    sl << "-Ss";
+    sl << QStringLiteral("-Ss");
     sl << pkgName;
     result = performQuery(sl);
   }
@@ -445,11 +445,11 @@ QByteArray UnixCommand::getExpacInfo(const QString &pkgName, const QString &info
   QByteArray result("");
   QProcess expac;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.insert("LC_ALL", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_ALL"), QStringLiteral("C"));
   expac.setProcessEnvironment(env);
-  QString expacStr = "expac -s \"%%1\" %2";
+  QString expacStr = QStringLiteral("expac -s \"%%1\" %2");
   expac.start(expacStr.arg(info, pkgName));
   expac.waitForFinished();
   result = expac.readAllStandardOutput();
@@ -468,9 +468,9 @@ QByteArray UnixCommand::getPackageInformation(const QString &pkgName, bool forei
   QStringList args;
 
   if(foreignPackage)
-    args << "-Qi";
+    args << QStringLiteral("-Qi");
   else
-    args << "-Si";
+    args << QStringLiteral("-Si");
 
   if (pkgName.isEmpty() == false) // enables get for all ("")
     args << pkgName;
@@ -485,7 +485,7 @@ QByteArray UnixCommand::getPackageInformation(const QString &pkgName, bool forei
 QByteArray UnixCommand::getPackageContentsUsingPacman(const QString& pkgName)
 {
   QStringList args;
-  args << "-Ql";
+  args << QStringLiteral("-Ql");
   args << pkgName;
 
   QByteArray res = performQuery(args);
@@ -502,7 +502,7 @@ bool UnixCommand::isPkgfileInstalled()
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
   pkgfile.setProcessEnvironment(env);
 
-  pkgfile.start("pkgfile -V");
+  pkgfile.start(QStringLiteral("pkgfile -V"));
   pkgfile.waitForFinished();
 
   return pkgfile.exitStatus() == QProcess::NormalExit;
@@ -518,8 +518,8 @@ QByteArray UnixCommand::getPackageContentsUsingPkgfile(const QString &pkgName)
   QByteArray result("");
   QProcess pkgfile;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   pkgfile.setProcessEnvironment(env);
 
   pkgfile.start("pkgfile -l " + pkgName);
@@ -535,18 +535,18 @@ QByteArray UnixCommand::getPackageContentsUsingPkgfile(const QString &pkgName)
 QString UnixCommand::getPackageByFilePath(const QString &filePath)
 {
   QStringList sl;
-  sl << "-Qo";
+  sl << QStringLiteral("-Qo");
   sl << filePath;
 
   QString out = performQuery(sl);
-  QStringList s = out.split("\n", QString::SkipEmptyParts);
+  QStringList s = out.split(QStringLiteral("\n"), QString::SkipEmptyParts);
 
   if (s.count() >= 1)
   {
-    QStringList res = s.at(0).split(" ", QString::SkipEmptyParts);
+    QStringList res = s.at(0).split(QStringLiteral(" "), QString::SkipEmptyParts);
     return res.at(res.count()-2);
   }
-  else return "";
+  else return QLatin1String("");
 }
 
 /*
@@ -556,14 +556,14 @@ QStringList UnixCommand::getFilePathSuggestions(const QString &file)
 {
   QProcess slocate;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   slocate.setProcessEnvironment(env);
   slocate.start("slocate -l 8 " + file);
   slocate.waitForFinished();
 
   QString ba = slocate.readAllStandardOutput();
-  return ba.split("\n", QString::SkipEmptyParts);
+  return ba.split(QStringLiteral("\n"), QString::SkipEmptyParts);
 }
 
 /*
@@ -571,7 +571,7 @@ QStringList UnixCommand::getFilePathSuggestions(const QString &file)
  */
 QByteArray UnixCommand::getPackageGroups()
 {
-  QByteArray res = performQuery(QStringList("-Sg"));
+  QByteArray res = performQuery(QStringList(QStringLiteral("-Sg")));
   return res;
 }
 
@@ -581,7 +581,7 @@ QByteArray UnixCommand::getPackageGroups()
 QByteArray UnixCommand::getPackagesFromGroup(const QString &groupName)
 {
   QByteArray res =
-      performQuery(QString("--print-format \"%r %n\" -Spg " ) + groupName);
+      performQuery(QStringLiteral("--print-format \"%r %n\" -Spg " ) + groupName);
 
   return res;
 }
@@ -599,7 +599,7 @@ QByteArray UnixCommand::getTargetUpgradeList(const QString &pkgName)
   }
   else
   {
-    args = "--print-format \"%n %v %s\" -Spu";
+    args = QStringLiteral("--print-format \"%n %v %s\" -Spu");
   }
 
   QByteArray res = performQuery(args);
@@ -626,12 +626,12 @@ QString UnixCommand::getSystemArchitecture()
   QStringList slParam;
   QProcess proc;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   proc.setProcessEnvironment(env);
 
-  slParam << "-m";
-  proc.start("uname", slParam);
+  slParam << QStringLiteral("-m");
+  proc.start(QStringLiteral("uname"), slParam);
   proc.waitForFinished();
 
   QString out = proc.readAllStandardOutput();
@@ -682,14 +682,14 @@ bool UnixCommand::hasInternetConnection()
 bool UnixCommand::doInternetPingTest()
 {
   QTcpSocket socket;
-  QString hostname = "www.google.com";
+  QString hostname = QStringLiteral("www.google.com");
 
   socket.connectToHost(hostname, 80);
   if (socket.waitForConnected(5000))
     return true;
   else
   {
-    hostname = "www.baidu.com";
+    hostname = QStringLiteral("www.baidu.com");
     socket.connectToHost(hostname, 80);
     if (socket.waitForConnected(5000))
       return true;
@@ -712,7 +712,7 @@ bool UnixCommand::hasTheExecutable( const QString& exeName )
   QString out = proc.readAllStandardOutput();
   proc.close();
 
-  if (out.isEmpty() || out.count("which") > 0) return false;
+  if (out.isEmpty() || out.count(QStringLiteral("which")) > 0) return false;
   else return true;
 }
 
@@ -723,8 +723,8 @@ void UnixCommand::removeSharedMemFiles()
 {
   QDir tempDir(QDir::tempPath());
   QStringList nameFilters;
-  nameFilters << "qipc_sharedmemory_orgarntoctopi*"
-              << "qipc_systemsem_orgarntoctopi*";
+  nameFilters << QStringLiteral("qipc_sharedmemory_orgarntoctopi*")
+              << QStringLiteral("qipc_systemsem_orgarntoctopi*");
 
   QFileInfoList list = tempDir.entryInfoList(nameFilters, QDir::Dirs | QDir::Files | QDir::System | QDir::Hidden);
 
@@ -755,10 +755,10 @@ void UnixCommand::removeTemporaryFiles()
 {
   QDir tempDir(QDir::tempPath());
   QStringList nameFilters;
-  nameFilters << "qtsingleapp-Octopi*" << "qtsingleapp-CacheC*" << "qtsingleapp-Reposi*"
+  nameFilters << QStringLiteral("qtsingleapp-Octopi*") << QStringLiteral("qtsingleapp-CacheC*") << QStringLiteral("qtsingleapp-Reposi*")
               //<< "qipc_sharedmemory_orgarntoctopi*"
               //<< "qipc_systemsem_orgarntoctopi*"
-              << ".qt_temp_octopi*";
+              << QStringLiteral(".qt_temp_octopi*");
   QFileInfoList list = tempDir.entryInfoList(nameFilters, QDir::Dirs | QDir::Files | QDir::System | QDir::Hidden);
 
   foreach(QFileInfo file, list){
@@ -798,8 +798,8 @@ QByteArray UnixCommand::execCommandAsNormalUserExt(const QString &pCommand)
   QByteArray res;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   p.setProcessEnvironment(env);
 
   p.start(pCommand);
@@ -816,8 +816,8 @@ void UnixCommand::execCommand(const QString &pCommand)
 {
   QProcess p;
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   p.setProcessEnvironment(env);
 
   p.start(WMHelper::getSUCommand() + getShell() + " -c \"" + pCommand + "\"");
@@ -889,12 +889,12 @@ bool UnixCommand::isTextFile(QString fileName)
   init:
   QProcess *p = new QProcess();
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   p->setProcessEnvironment(env);
 
   QStringList s(fileName);
-  p->start( "file", s );
+  p->start( QStringLiteral("file"), s );
   p->waitForFinished();
 
   QString output = p->readAllStandardOutput();
@@ -902,7 +902,7 @@ bool UnixCommand::isTextFile(QString fileName)
   delete p;
 
   //If it's a symbolic link, let's discover what is the real target
-  if (output.contains(": symbolic link to"))
+  if (output.contains(QLatin1String(": symbolic link to")))
   {
     QFileInfo fi(fileName);
     fileName = fi.symLinkTarget();
@@ -910,12 +910,12 @@ bool UnixCommand::isTextFile(QString fileName)
   }
   else
   {
-    int from = output.indexOf(":", 0)+1;
+    int from = output.indexOf(QLatin1String(":"), 0)+1;
 
-    return (((output.indexOf( "ASCII", from ) != -1) ||
-            (output.indexOf( "text", from ) != -1) ||
-            (output.indexOf( "empty", from ) != -1)) &&
-            (output.indexOf( "executable", from) == -1));
+    return (((output.indexOf( QLatin1String("ASCII"), from ) != -1) ||
+            (output.indexOf( QLatin1String("text"), from ) != -1) ||
+            (output.indexOf( QLatin1String("empty"), from ) != -1)) &&
+            (output.indexOf( QLatin1String("executable"), from) == -1));
   }
 }
 
@@ -954,12 +954,12 @@ void UnixCommand::executeCommand(const QString &pCommand)
 
   //COLUMNS variable code!
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.remove("LANG");
-  env.remove("LC_MESSAGES");
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.remove("COLUMNS");
-  env.insert("COLUMNS", "132");
+  env.remove(QStringLiteral("LANG"));
+  env.remove(QStringLiteral("LC_MESSAGES"));
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.remove(QStringLiteral("COLUMNS"));
+  env.insert(QStringLiteral("COLUMNS"), QStringLiteral("132"));
   m_process->setProcessEnvironment(env);
 
   QString suCommand = WMHelper::getSUCommand();
@@ -979,12 +979,12 @@ void UnixCommand::executeCommandWithSharedMemHelper(const QString &pCommand, QSh
 
   //COLUMNS variable code!
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.remove("LANG");
-  env.remove("LC_MESSAGES");
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.remove("COLUMNS");
-  env.insert("COLUMNS", "132");
+  env.remove(QStringLiteral("LANG"));
+  env.remove(QStringLiteral("LC_MESSAGES"));
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.remove(QStringLiteral("COLUMNS"));
+  env.insert(QStringLiteral("COLUMNS"), QStringLiteral("132"));
   m_process->setProcessEnvironment(env);
 
   QString suCommand = WMHelper::getSUCommand();
@@ -1104,7 +1104,7 @@ QString UnixCommand::buildOctopiHelperCommandWithSharedMem(const QString &pComma
 {
   QString octopiHelperCommandParameter;
   QString suCommand = WMHelper::getSUCommand();
-  octopiHelperCommandParameter = " -ts";
+  octopiHelperCommandParameter = QStringLiteral(" -ts");
   suCommand += ctn_OCTOPI_HELPER_PATH + octopiHelperCommandParameter;
 
   QStringList commandList;
@@ -1112,9 +1112,9 @@ QString UnixCommand::buildOctopiHelperCommandWithSharedMem(const QString &pComma
   QByteArray sharedData;
 
   //If this is a multiple command string, let's break it
-  if (pCommand.contains(";"))
+  if (pCommand.contains(QLatin1String(";")))
   {
-    commandList = pCommand.split(";", QString::SkipEmptyParts);
+    commandList = pCommand.split(QStringLiteral(";"), QString::SkipEmptyParts);
     foreach(QString line, commandList)
     {
       commands += line.trimmed() + "\n";
@@ -1211,9 +1211,9 @@ bool UnixCommand::isAppRunning(const QString &appName, bool justOneInstance)
   QStringList slParam;
   QProcess proc;
 
-  slParam << "-C";
+  slParam << QStringLiteral("-C");
   slParam << appName;
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForFinished();
   QString out = proc.readAll();
   proc.close();
@@ -1243,18 +1243,18 @@ bool UnixCommand::isOctoToolRunning(const QString &octoToolName)
 
   QProcess proc;
   proc.setProcessEnvironment(getProcessEnvironment());
-  QString cmd = "/usr/bin/ps -C %1 -o command";
+  QString cmd = QStringLiteral("/usr/bin/ps -C %1 -o command");
   cmd = cmd.arg(octoToolName);
   proc.start(cmd);
   proc.waitForFinished();
   QString out = proc.readAll().trimmed();
-  if (out.contains("|")) return false;
-  out=out.remove("\n");
-  out=out.remove("COMMAND");
+  if (out.contains(QLatin1String("|"))) return false;
+  out=out.remove(QStringLiteral("\n"));
+  out=out.remove(QStringLiteral("COMMAND"));
 
-  if (octoToolName=="octopi-cachecle")
+  if (octoToolName==QLatin1String("octopi-cachecle"))
   {
-    if (out == "/usr/bin/octopi-cachecleaner") res=true;
+    if (out == QLatin1String("/usr/bin/octopi-cachecleaner")) res=true;
   }
   else if ((out == "/usr/bin/" + octoToolName) || out.contains("/usr/bin/" + octoToolName + " ")) res=true;
 
@@ -1268,7 +1268,7 @@ bool UnixCommand::isUserInWheelGroup()
 {
   bool result=false;
   QProcess groups;
-  groups.start("groups");
+  groups.start(QStringLiteral("groups"));
   groups.waitForFinished();
   if (groups.readAllStandardOutput().contains("wheel"))
     result=true;
@@ -1293,13 +1293,13 @@ bool UnixCommand::isPackageInstalled(const QString &pkgName)
 bool UnixCommand::isILoveCandyEnabled()
 {
   bool res=false;
-  QFile file("/etc/pacman.conf");
+  QFile file(QStringLiteral("/etc/pacman.conf"));
 
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
     return false;
 
   QString contents = file.readAll();
-  int end = contents.indexOf("ILoveCandy");
+  int end = contents.indexOf(QLatin1String("ILoveCandy"));
   if (end != -1)
   {
     //Does it contains a # before it???
@@ -1325,7 +1325,7 @@ bool UnixCommand::isILoveCandyEnabled()
 QStringList UnixCommand::getFieldFromPacmanConf(const QString &fieldName)
 {
   QStringList result;
-  QFile file("/etc/pacman.conf");
+  QFile file(QStringLiteral("/etc/pacman.conf"));
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
     return result;
 
@@ -1349,14 +1349,14 @@ QStringList UnixCommand::getFieldFromPacmanConf(const QString &fieldName)
       if (str.isEmpty())
       {
         QString ignorePkg = contents.mid(end);
-        int equal = ignorePkg.indexOf("=");
-        int newLine = ignorePkg.indexOf("\n");
+        int equal = ignorePkg.indexOf(QLatin1String("="));
+        int newLine = ignorePkg.indexOf(QLatin1String("\n"));
 
         ignorePkg = ignorePkg.mid(equal+1, newLine-(equal+1)).trimmed();
-        result += ignorePkg.split(QRegularExpression("\\s+"), QString::SkipEmptyParts);
+        result += ignorePkg.split(QRegularExpression(QStringLiteral("\\s+")), QString::SkipEmptyParts);
         from = end + newLine;
       }
-      else if (str != "#")
+      else if (str != QLatin1String("#"))
         from += end + ctn_FIELD_LENGTH;
       else
         from += ctn_FIELD_LENGTH;
@@ -1377,8 +1377,8 @@ QStringList UnixCommand::getIgnorePkgsFromPacmanConf()
   QStringList resPkgs;
   QStringList resGroups;
 
-  resPkgs = getFieldFromPacmanConf("IgnorePkg");
-  resGroups = getFieldFromPacmanConf("IgnoreGroup");
+  resPkgs = getFieldFromPacmanConf(QStringLiteral("IgnorePkg"));
+  resGroups = getFieldFromPacmanConf(QStringLiteral("IgnoreGroup"));
 
   if (!resGroups.isEmpty())
   {
@@ -1411,9 +1411,9 @@ LinuxDistro UnixCommand::getLinuxDistro()
 
   if (firstTime)
   {
-    if (QFile::exists("/etc/os-release"))
+    if (QFile::exists(QStringLiteral("/etc/os-release")))
     {
-      QFile file("/etc/os-release");
+      QFile file(QStringLiteral("/etc/os-release"));
 
       if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         ret = ectn_UNKNOWN;
@@ -1424,32 +1424,32 @@ LinuxDistro UnixCommand::getLinuxDistro()
       {
         ret = ectn_ANTERGOS;
       }*/
-      if (contents.contains(QRegularExpression("ArchBang")))
+      if (contents.contains(QRegularExpression(QStringLiteral("ArchBang"))))
       {
         ret = ectn_ARCHBANGLINUX;
       }
-      else if (contents.contains(QRegularExpression("Arch Linux")) ||
-               (contents.contains(QRegularExpression("Arcolinux"))))
+      else if (contents.contains(QRegularExpression(QStringLiteral("Arch Linux"))) ||
+               (contents.contains(QRegularExpression(QStringLiteral("Arcolinux")))))
       {
         ret = ectn_ARCHLINUX;
       }
-      else if (contents.contains(QRegularExpression("Chakra")))
+      else if (contents.contains(QRegularExpression(QStringLiteral("Chakra"))))
       {
         ret = ectn_CHAKRA;
       }
-      else if (contents.contains(QRegularExpression("Condres OS")))
+      else if (contents.contains(QRegularExpression(QStringLiteral("Condres OS"))))
       {
         ret = ectn_CONDRESOS;
       }
-      else if (contents.contains(QRegularExpression("EndeavourOS")))
+      else if (contents.contains(QRegularExpression(QStringLiteral("EndeavourOS"))))
       {
         ret = ectn_ENDEAVOUROS;
       }
-      else if (contents.contains(QRegularExpression("KaOS")))
+      else if (contents.contains(QRegularExpression(QStringLiteral("KaOS"))))
       {
         ret = ectn_KAOS;
       }
-      else if (contents.contains(QRegularExpression("Manjaro")))
+      else if (contents.contains(QRegularExpression(QStringLiteral("Manjaro"))))
       {
         ret = ectn_MANJAROLINUX;
       }
@@ -1457,7 +1457,7 @@ LinuxDistro UnixCommand::getLinuxDistro()
       {
         ret = ectn_NETRUNNER;
       }*/
-      else if (contents.contains(QRegularExpression("Parabola GNU/Linux-libre")))
+      else if (contents.contains(QRegularExpression(QStringLiteral("Parabola GNU/Linux-libre"))))
       {
         ret = ectn_PARABOLA;
       }
@@ -1484,20 +1484,20 @@ LinuxDistro UnixCommand::getLinuxDistro()
  */
 QString UnixCommand::getLinuxDistroPrettyName()
 {
-  static QString ret("");
+  static QString ret(QLatin1String(""));
   static bool firstTime = true;
 
   if (firstTime)
   {
-    if (QFile::exists("/etc/os-release"))
+    if (QFile::exists(QStringLiteral("/etc/os-release")))
     {
-      QFile file("/etc/os-release");
+      QFile file(QStringLiteral("/etc/os-release"));
       if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-        ret = "";
+        ret = QLatin1String("");
 
       QString contents = file.readAll();
-      int ind = contents.indexOf("PRETTY_NAME", Qt::CaseInsensitive);
-      int end = contents.indexOf("\n", ind);
+      int ind = contents.indexOf(QLatin1String("PRETTY_NAME"), Qt::CaseInsensitive);
+      int end = contents.indexOf(QLatin1String("\n"), ind);
 
       if (ind != -1)
       {
@@ -1516,10 +1516,10 @@ QString UnixCommand::getLinuxDistroPrettyName()
  */
 QString UnixCommand::getPacmanVersion()
 {
-  QString v = performQuery("--version");
-  QString res = "???";
-  int p = v.indexOf("Pacman");
-  int q = v.indexOf("- libalpm");
+  QString v = performQuery(QStringLiteral("--version"));
+  QString res = QStringLiteral("???");
+  int p = v.indexOf(QLatin1String("Pacman"));
+  int q = v.indexOf(QLatin1String("- libalpm"));
 
   if (p >=0 && q >= 0)
   {
@@ -1569,12 +1569,12 @@ bool UnixCommand::isPacmanDbLocked()
 QProcessEnvironment UnixCommand::getProcessEnvironment()
 {
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-  env.remove("LANG");
-  env.remove("LC_MESSAGES");
-  env.insert("LANG", "C");
-  env.insert("LC_MESSAGES", "C");
-  env.remove("COLUMNS");
-  env.insert("COLUMNS", "132");
+  env.remove(QStringLiteral("LANG"));
+  env.remove(QStringLiteral("LC_MESSAGES"));
+  env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
+  env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
+  env.remove(QStringLiteral("COLUMNS"));
+  env.insert(QStringLiteral("COLUMNS"), QStringLiteral("132"));
   return env;
 }
 
@@ -1587,15 +1587,15 @@ bool UnixCommand::isOctopiHelperRunning()
 
   QProcess proc;
   proc.setProcessEnvironment(getProcessEnvironment());
-  QString cmd = "ps -C %1 -o command";
+  QString cmd = QStringLiteral("ps -C %1 -o command");
   QString octoToolName = ctn_OCTOPI_HELPER_NAME;
   cmd = cmd.arg(octoToolName);
   proc.start(cmd);
   proc.waitForFinished();
   QString out = proc.readAll().trimmed();
-  if (out.contains("|")) return false;
-  out=out.remove("\n");
-  out=out.remove("COMMAND");
+  if (out.contains(QLatin1String("|"))) return false;
+  out=out.remove(QStringLiteral("\n"));
+  out=out.remove(QStringLiteral("COMMAND"));
   if ((out == "/usr/lib/octopi/" + octoToolName) || out.contains("/usr/lib/octopi/" + octoToolName + " ")) res=true;
 
   return res;

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -98,7 +98,7 @@ QString UnixCommand::runCommand(const QString& commandToRun)
   proc.waitForStarted();
   proc.waitForFinished(-1);
 
-  QString res = proc.readAllStandardError();
+  QString res = QString::fromUtf8(proc.readAllStandardError());
   proc.close();
 
   return res;
@@ -121,7 +121,7 @@ QString UnixCommand::runCurlCommand(const QString& commandToRun){
 
   if (proc.exitCode() != 0)
   {
-    res = proc.readAllStandardError();
+    res = QString::fromUtf8(proc.readAllStandardError());
   }
 
   proc.close();
@@ -138,18 +138,18 @@ QString UnixCommand::discoverBinaryPath(const QString& binary){
   env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   proc.setProcessEnvironment(env);
 
-  proc.start("/bin/sh -c \"which " + binary + "\"");
+  proc.start(QLatin1String("/bin/sh -c \"which ") + binary + QLatin1String("\""));
   proc.waitForFinished();
-  QString res = proc.readAllStandardOutput();
+  QString res = QString::fromUtf8(proc.readAllStandardOutput());
 
   proc.close();
-  res = res.remove('\n');
+  res = res.remove(QLatin1Char('\n'));
 
   //If it still didn't find it, try "/sbin" dir...
   if (res.isEmpty()){
-    QFile fbin("/sbin/" + binary);
+    QFile fbin(QLatin1String("/sbin/") + binary);
     if (fbin.exists()){
-      res = "/sbin/" + binary;
+      res = QLatin1String("/sbin/") + binary;
     }
   }
 
@@ -164,7 +164,7 @@ bool UnixCommand::cleanPacmanCache()
 {
   QProcess pacman;
   QString commandStr = QStringLiteral("\"yes | pacman -Scc\"");
-  QString command = WMHelper::getSUCommand() + " " + commandStr;
+  QString command = WMHelper::getSUCommand() + QLatin1String(" ") + commandStr;
   pacman.start(command);
   pacman.waitForFinished();
 
@@ -207,7 +207,7 @@ QByteArray UnixCommand::performQuery(const QString &args)
   env.insert(QStringLiteral("LC_ALL"), QStringLiteral("C"));
   pacman.setProcessEnvironment(env);
 
-  pacman.start("pacman " + args);
+  pacman.start(QLatin1String("pacman ") + args);
   pacman.waitForFinished();
   result = pacman.readAllStandardOutput();
   pacman.close();
@@ -226,7 +226,7 @@ QByteArray UnixCommand::performAURCommand(const QString &args)
   env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   aur.setProcessEnvironment(env);
 
-  aur.start(Package::getForeignRepositoryToolNameParam() + " " + args);
+  aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1Char(' ') + args);
   aur.waitForFinished(-1);
   result = aur.readAllStandardOutput();
 
@@ -239,7 +239,7 @@ QByteArray UnixCommand::performAURCommand(const QString &args)
  */
 bool UnixCommand::hasPackage(const QString &pkgName)
 {
-  QString res = performQuery("-Ss " + pkgName);
+  QString res = QString::fromUtf8(performQuery(QLatin1String("-Ss ") + pkgName));
   return !res.isEmpty();
 }
 
@@ -257,9 +257,9 @@ QByteArray UnixCommand::getAURUrl(const QString &pkgName)
   aur.setProcessEnvironment(env);
 
   if (Package::getForeignRepositoryToolName() == ctn_CHASER_TOOL)
-    aur.start(Package::getForeignRepositoryToolNameParam() + " info " + pkgName);
+    aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" info ") + pkgName);
   else
-    aur.start(Package::getForeignRepositoryToolNameParam() + " -Sia " + pkgName);
+    aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -Sia ") + pkgName);
 
   aur.waitForFinished(-1);
 
@@ -281,19 +281,19 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
   aur.setProcessEnvironment(env);
 
   if (UnixCommand::getLinuxDistro() == ectn_KAOS)
-    aur.start(Package::getForeignRepositoryToolNameParam() + " -l ");
+    aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -l "));
   else
   {
     if (Package::getForeignRepositoryToolName() == ctn_YAOURT_TOOL)
-      aur.start(Package::getForeignRepositoryToolNameParam() + " --nocolor -Ss " + searchString);
+      aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" --nocolor -Ss ") + searchString);
     else if (Package::getForeignRepositoryToolName() == ctn_TRIZEN_TOOL)
-        aur.start(Package::getForeignRepositoryToolNameParam() + " --nocolors -Ssa " + searchString);
+        aur.start(Package::getForeignRepositoryToolNameParam() + tr(" --nocolors -Ssa ") + searchString);
     else if (Package::getForeignRepositoryToolName() == ctn_PIKAUR_TOOL || Package::getForeignRepositoryToolName() == ctn_YAY_TOOL)
-        aur.start(Package::getForeignRepositoryToolNameParam() + " --color=never -Ss --aur " + searchString);
+        aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" --color=never -Ss --aur ") + searchString);
     else if (Package::getForeignRepositoryToolName() == ctn_CHASER_TOOL)
-      aur.start(Package::getForeignRepositoryToolNameParam() + " search " + searchString);
+      aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" search ") + searchString);
     else
-      aur.start(Package::getForeignRepositoryToolNameParam() + " -Ss " + searchString);
+      aur.start(Package::getForeignRepositoryToolNameParam() + QLatin1String(" -Ss ") + searchString);
   }
 
   aur.waitForFinished(-1);
@@ -301,8 +301,8 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
 
   if (UnixCommand::getLinuxDistro() == ectn_KAOS)
   {
-    QString res = result;
-    res.remove("\033");
+    QString res = QString::fromUtf8(result);
+    res.remove(QStringLiteral("\033"));
     res.remove(QStringLiteral("[1m"));
     res.remove(QStringLiteral("[m"));
     res.remove(QStringLiteral("[1;32m"));
@@ -313,8 +313,8 @@ QByteArray UnixCommand::getAURPackageList(const QString &searchString)
   }
   else if (UnixCommand::getLinuxDistro() == ectn_CHAKRA)
   {
-    QString res = result;
-    res.remove("\033");
+    QString res = QString::fromUtf8(result);
+    res.remove(QStringLiteral("\033"));
     res.remove(QStringLiteral("[0m"));
     res.remove(QStringLiteral("[1m"));
     res.remove(QStringLiteral("[m"));
@@ -420,7 +420,7 @@ QByteArray UnixCommand::getPackageList(const QString &pkgName)
  */
 QByteArray UnixCommand::getKCPPackageInformation(const QString &pkgName)
 {
-  QString args = "--information " + pkgName;
+  QString args = QLatin1String("--information ") + pkgName;
   QByteArray result = performAURCommand(args);
   return result;
 }
@@ -522,7 +522,7 @@ QByteArray UnixCommand::getPackageContentsUsingPkgfile(const QString &pkgName)
   env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   pkgfile.setProcessEnvironment(env);
 
-  pkgfile.start("pkgfile -l " + pkgName);
+  pkgfile.start(QLatin1String("pkgfile -l ") + pkgName);
   pkgfile.waitForFinished();
   result = pkgfile.readAllStandardOutput();
 
@@ -538,7 +538,7 @@ QString UnixCommand::getPackageByFilePath(const QString &filePath)
   sl << QStringLiteral("-Qo");
   sl << filePath;
 
-  QString out = performQuery(sl);
+  QString out = QString::fromUtf8(performQuery(sl));
   QStringList s = out.split(QStringLiteral("\n"), QString::SkipEmptyParts);
 
   if (s.count() >= 1)
@@ -559,10 +559,10 @@ QStringList UnixCommand::getFilePathSuggestions(const QString &file)
   env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
   env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   slocate.setProcessEnvironment(env);
-  slocate.start("slocate -l 8 " + file);
+  slocate.start(QLatin1String("slocate -l 8 ") + file);
   slocate.waitForFinished();
 
-  QString ba = slocate.readAllStandardOutput();
+  QString ba = QString::fromUtf8(slocate.readAllStandardOutput());
   return ba.split(QStringLiteral("\n"), QString::SkipEmptyParts);
 }
 
@@ -595,7 +595,7 @@ QByteArray UnixCommand::getTargetUpgradeList(const QString &pkgName)
 
   if(!pkgName.isEmpty())
   {
-    args = "--print-format \"%n %v %s\" -Sp " + pkgName;
+    args = QLatin1String("--print-format \"%n %v %s\" -Sp ") + pkgName;
   }
   else
   {
@@ -612,7 +612,7 @@ QByteArray UnixCommand::getTargetUpgradeList(const QString &pkgName)
 QByteArray UnixCommand::getTargetRemovalList(const QString &pkgName, const QString &removeCommand)
 {
   QString args;
-  args = "-" + removeCommand + "p " + pkgName;
+  args = QLatin1Char('-') + removeCommand + QLatin1String("p ") + pkgName;
 
   QByteArray res = performQuery(args);
   return res;
@@ -634,7 +634,7 @@ QString UnixCommand::getSystemArchitecture()
   proc.start(QStringLiteral("uname"), slParam);
   proc.waitForFinished();
 
-  QString out = proc.readAllStandardOutput();
+  QString out = QString::fromUtf8(proc.readAllStandardOutput());
   proc.close();
 
   return out;
@@ -705,11 +705,11 @@ bool UnixCommand::hasTheExecutable( const QString& exeName )
 {
   QProcess proc;
   proc.setProcessChannelMode(QProcess::MergedChannels);
-  QString sParam = "\"which " + exeName + "\"";
-  proc.start("/bin/sh -c " + sParam);
+  QString sParam = QLatin1String("\"which ") + exeName + QLatin1Char('"');
+  proc.start(QLatin1String("/bin/sh -c ") + sParam);
   proc.waitForFinished();
 
-  QString out = proc.readAllStandardOutput();
+  QString out = QString::fromUtf8(proc.readAllStandardOutput());
   proc.close();
 
   if (out.isEmpty() || out.count(QStringLiteral("which")) > 0) return false;
@@ -820,7 +820,7 @@ void UnixCommand::execCommand(const QString &pCommand)
   env.insert(QStringLiteral("LC_MESSAGES"), QStringLiteral("C"));
   p.setProcessEnvironment(env);
 
-  p.start(WMHelper::getSUCommand() + getShell() + " -c \"" + pCommand + "\"");
+  p.start(WMHelper::getSUCommand() + getShell() + QLatin1String(" -c \"") + pCommand + QLatin1Char('"'));
   p.waitForFinished(-1);
   p.close();
 }
@@ -897,7 +897,7 @@ bool UnixCommand::isTextFile(QString fileName)
   p->start( QStringLiteral("file"), s );
   p->waitForFinished();
 
-  QString output = p->readAllStandardOutput();
+  QString output = QString::fromUtf8(p->readAllStandardOutput());
   p->close();
   delete p;
 
@@ -963,7 +963,7 @@ void UnixCommand::executeCommand(const QString &pCommand)
   m_process->setProcessEnvironment(env);
 
   QString suCommand = WMHelper::getSUCommand();
-  command = suCommand + getShell() + " -c " + "\"" + pCommand + "\"";
+  command = suCommand + getShell() + QLatin1String(" -c ") + QLatin1Char('"') + pCommand + QLatin1Char('"');
   m_process->start(command);
 }
 
@@ -995,7 +995,7 @@ void UnixCommand::executeCommandWithSharedMemHelper(const QString &pCommand, QSh
   }
   else //We are not using "octopi-sudo" nor "lxqt-sudo" utility...*/
   {
-    command = suCommand + "\"" + pCommand + "\"";
+    command = suCommand + QLatin1Char('"') + pCommand + QLatin1Char('"');
   }
 
   m_process->start(command);
@@ -1061,7 +1061,7 @@ void UnixCommand::executeCommandAsNormalUser(const QString &pCommand)
 void UnixCommand::processReadyReadStandardOutput()
 {
   if (m_process->isOpen())
-    m_readAllStandardOutput = m_process->readAllStandardOutput();
+    m_readAllStandardOutput = QString::fromUtf8(m_process->readAllStandardOutput());
 }
 
 /*
@@ -1071,7 +1071,7 @@ void UnixCommand::processReadyReadStandardError()
 {
   if (m_process->isOpen())
   {
-    m_readAllStandardError = m_process->readAllStandardError();
+    m_readAllStandardError = QString::fromUtf8(m_process->readAllStandardError());
     m_errorString = m_process->errorString();
   }
 }
@@ -1117,13 +1117,13 @@ QString UnixCommand::buildOctopiHelperCommandWithSharedMem(const QString &pComma
     commandList = pCommand.split(QStringLiteral(";"), QString::SkipEmptyParts);
     foreach(QString line, commandList)
     {
-      commands += line.trimmed() + "\n";
+      commands += line.trimmed() + QLatin1Char('\n');
     }
   }
   else //We have just one command here
   {
     commandList << pCommand.trimmed();
-    commands += commandList.first() + "\n";
+    commands += commandList.first() + QLatin1Char('\n');
   }
 
   sharedData=commands.toLatin1();
@@ -1186,7 +1186,7 @@ int UnixCommand::cancelProcess(QSharedMemory *sharedMem)
 {
   QProcess pacman;
   QString suCommand = WMHelper::getSUCommand();
-  QString pCommand = "killall pacman; rm " + ctn_PACMAN_DATABASE_LOCK_FILE;
+  QString pCommand = QLatin1String("killall pacman; rm ") + ctn_PACMAN_DATABASE_LOCK_FILE;
   QString result;
 
   if (suCommand == WMHelper::getOctopiSudoCommand())
@@ -1194,7 +1194,7 @@ int UnixCommand::cancelProcess(QSharedMemory *sharedMem)
     result = buildOctopiHelperCommandWithSharedMem(pCommand, sharedMem);
   }
   else {
-    result = suCommand + "\"" + pCommand + "\"";
+    result = suCommand + QLatin1Char('"') + pCommand + QLatin1Char('"');
   }
 
   pacman.start(result);
@@ -1215,7 +1215,7 @@ bool UnixCommand::isAppRunning(const QString &appName, bool justOneInstance)
   slParam << appName;
   proc.start(QStringLiteral("ps"), slParam);
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (justOneInstance)
@@ -1247,7 +1247,7 @@ bool UnixCommand::isOctoToolRunning(const QString &octoToolName)
   cmd = cmd.arg(octoToolName);
   proc.start(cmd);
   proc.waitForFinished();
-  QString out = proc.readAll().trimmed();
+  QString out = QString::fromUtf8(proc.readAll().trimmed());
   if (out.contains(QLatin1String("|"))) return false;
   out=out.remove(QStringLiteral("\n"));
   out=out.remove(QStringLiteral("COMMAND"));
@@ -1256,7 +1256,7 @@ bool UnixCommand::isOctoToolRunning(const QString &octoToolName)
   {
     if (out == QLatin1String("/usr/bin/octopi-cachecleaner")) res=true;
   }
-  else if ((out == "/usr/bin/" + octoToolName) || out.contains("/usr/bin/" + octoToolName + " ")) res=true;
+  else if ((out == QLatin1String("/usr/bin/") + octoToolName) || out.contains(QLatin1String("/usr/bin/") + octoToolName + QLatin1Char(' '))) res=true;
 
   return res;
 }
@@ -1281,7 +1281,7 @@ bool UnixCommand::isUserInWheelGroup()
 bool UnixCommand::isPackageInstalled(const QString &pkgName)
 {
   QProcess pacman;
-  QString command = "pacman -Q " + pkgName;
+  QString command = QLatin1String("pacman -Q ") + pkgName;
   pacman.start(command);
   pacman.waitForFinished();
   return (pacman.exitCode() == 0);
@@ -1298,7 +1298,7 @@ bool UnixCommand::isILoveCandyEnabled()
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
     return false;
 
-  QString contents = file.readAll();
+  QString contents = QString::fromUtf8(file.readAll());
   int end = contents.indexOf(QLatin1String("ILoveCandy"));
   if (end != -1)
   {
@@ -1306,7 +1306,7 @@ bool UnixCommand::isILoveCandyEnabled()
     int start = end;
     do{
       start--;
-    }while (contents.at(start) != '\n');
+    }while (contents.at(start) != QLatin1Char('\n'));
 
     QString str = contents.mid(start+1, (end-start-1)).trimmed();
 
@@ -1329,7 +1329,7 @@ QStringList UnixCommand::getFieldFromPacmanConf(const QString &fieldName)
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
     return result;
 
-  QString contents = file.readAll();
+  QString contents = QString::fromUtf8(file.readAll());
   int from = 0;
   const int ctn_FIELD_LENGTH = fieldName.length();
 
@@ -1342,7 +1342,7 @@ QStringList UnixCommand::getFieldFromPacmanConf(const QString &fieldName)
       int start = end;
       do{
         start--;
-      }while (contents.at(start) != '\n');
+      }while (contents.at(start) != QLatin1Char('\n'));
 
       QString str = contents.mid(start+1, (end-start-1)).trimmed();
 
@@ -1418,7 +1418,7 @@ LinuxDistro UnixCommand::getLinuxDistro()
       if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         ret = ectn_UNKNOWN;
 
-      QString contents = file.readAll();
+      QString contents = QString::fromUtf8(file.readAll());
 
       /*if (contents.contains(QRegularExpression("Antergos")))
       {
@@ -1495,7 +1495,7 @@ QString UnixCommand::getLinuxDistroPrettyName()
       if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         ret = QLatin1String("");
 
-      QString contents = file.readAll();
+      QString contents = QString::fromUtf8(file.readAll());
       int ind = contents.indexOf(QLatin1String("PRETTY_NAME"), Qt::CaseInsensitive);
       int end = contents.indexOf(QLatin1String("\n"), ind);
 
@@ -1516,7 +1516,7 @@ QString UnixCommand::getLinuxDistroPrettyName()
  */
 QString UnixCommand::getPacmanVersion()
 {
-  QString v = performQuery(QStringLiteral("--version"));
+  QString v = QString::fromUtf8(performQuery(QStringLiteral("--version")));
   QString res = QStringLiteral("???");
   int p = v.indexOf(QLatin1String("Pacman"));
   int q = v.indexOf(QLatin1String("- libalpm"));
@@ -1592,11 +1592,11 @@ bool UnixCommand::isOctopiHelperRunning()
   cmd = cmd.arg(octoToolName);
   proc.start(cmd);
   proc.waitForFinished();
-  QString out = proc.readAll().trimmed();
+  QString out = QString::fromUtf8(proc.readAll().trimmed());
   if (out.contains(QLatin1String("|"))) return false;
   out=out.remove(QStringLiteral("\n"));
   out=out.remove(QStringLiteral("COMMAND"));
-  if ((out == "/usr/lib/octopi/" + octoToolName) || out.contains("/usr/lib/octopi/" + octoToolName + " ")) res=true;
+  if ((out == QLatin1String("/usr/lib/octopi/") + octoToolName) || out.contains(QLatin1String("/usr/lib/octopi/") + octoToolName + QLatin1String(" "))) res=true;
 
   return res;
 }

--- a/src/unixcommand.h
+++ b/src/unixcommand.h
@@ -94,7 +94,7 @@ public:
   static QByteArray getOutdatedPackageList();
   static QByteArray getOutdatedAURPackageList();
   static QByteArray getForeignPackageList();
-  static QByteArray getPackageList(const QString &pkgName = "");
+  static QByteArray getPackageList(const QString &pkgName = QLatin1String(""));
 
   static QByteArray getKCPPackageInformation(const QString &pkgName);
   static QByteArray getExpacInfo(const QString &pkgName, const QString &info);
@@ -109,7 +109,7 @@ public:
 
   static QByteArray getPackageGroups();
   static QByteArray getPackagesFromGroup(const QString &groupName);
-  static QByteArray getTargetUpgradeList(const QString &pkgName = "");
+  static QByteArray getTargetUpgradeList(const QString &pkgName = QLatin1String(""));
   static QByteArray getTargetRemovalList(const QString &pkgName, const QString &removeCommand);
 
   static QString getSystemArchitecture();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -119,7 +119,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
   QFile fileRss(rssPath);
   if (fileRss.exists())
   {
-    if (!fileRss.open(QIODevice::ReadOnly | QIODevice::Text)) res = "";
+    if (!fileRss.open(QIODevice::ReadOnly | QIODevice::Text)) res = QLatin1String("");
     QTextStream in2(&fileRss);
     contentsRss = in2.readAll();
     fileRss.close();
@@ -127,7 +127,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
 
   if(searchForLatestNews && UnixCommand::hasInternetConnection() && distro != ectn_UNKNOWN)
   {    
-    QString curlCommand = "curl %1 -o %2";
+    QString curlCommand = QStringLiteral("curl %1 -o %2");
     QString distroRSSUrl = SettingsManager::getDistroRSSUrl();
 
     /*if (distro == ectn_ENDEAVOUROS || distro == ectn_ANTERGOS)
@@ -140,17 +140,17 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
     }
     else if (distro == ectn_CHAKRA)
     {
-      curlCommand = "curl -k %1 -o %2";
+      curlCommand = QStringLiteral("curl -k %1 -o %2");
       curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_CONDRESOS)
     {
-      curlCommand = "curl -A \"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0\" -k \"%1\" -o %2";
+      curlCommand = QStringLiteral("curl -A \"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0\" -k \"%1\" -o %2");
       curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_KAOS)
     {
-      curlCommand = "curl -k %1 -o %2";
+      curlCommand = QStringLiteral("curl -k %1 -o %2");
       curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
     else if (distro == ectn_MANJAROLINUX)
@@ -164,7 +164,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
     else if (distro == ectn_PARABOLA)
     {
       //Parabola has a certificate which is not "trusted" by default, so we use "curl -k"
-      curlCommand = "curl -k %1 -o %2";
+      curlCommand = QStringLiteral("curl -k %1 -o %2");
       curlCommand = curlCommand.arg(distroRSSUrl, tmpRssPath);
     }
 
@@ -180,7 +180,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
         if (!fileRss.open(QIODevice::ReadOnly | QIODevice::Text)) return("");
         QTextStream in2(&fileRss);
         contentsRss = in2.readAll();
-        contentsRss = contentsRss.remove(QRegularExpression("^\\s*"));
+        contentsRss = contentsRss.remove(QRegularExpression(QStringLiteral("^\\s*")));
         fileRss.close();
         fileRss.remove();
         if (!fileRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
@@ -191,7 +191,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
         {
           //Let's remove <lastBuildDate>XYZ</lastBuildDate> text so our SHA1 test works as expected
           //qDebug() << contentsRss;
-          contentsRss.replace(QRegularExpression("(\\t*)(\\n*)<lastBuildDate>(.*)</lastBuildDate>(\\t*)(\\n*)"), "");
+          contentsRss.replace(QRegularExpression(QStringLiteral("(\\t*)(\\n*)<lastBuildDate>(.*)</lastBuildDate>(\\t*)(\\n*)")), QLatin1String(""));
           fileRss.close();
           fileRss.remove();
           if (!fileRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
@@ -213,7 +213,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
         if (!fileTmpRss.open(QIODevice::ReadOnly | QIODevice::Text)) return("");
         QTextStream in(&fileTmpRss);
         contentsTmpRss = in.readAll();
-        contentsTmpRss = contentsTmpRss.remove(QRegularExpression("^\\s*"));
+        contentsTmpRss = contentsTmpRss.remove(QRegularExpression(QStringLiteral("^\\s*")));
         fileTmpRss.close();
         fileTmpRss.remove();
         if (!fileTmpRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
@@ -223,7 +223,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
         if (distro == ectn_CONDRESOS)
         {
           //Let's remove <lastBuildDate>XYZ</lastBuildDate> text so our SHA1 test works as expected
-          contentsTmpRss.replace(QRegularExpression("(\\t*)(\\n*)<lastBuildDate>(.*)</lastBuildDate>(\\t*)(\\n*)"), "");
+          contentsTmpRss.replace(QRegularExpression(QStringLiteral("(\\t*)(\\n*)<lastBuildDate>(.*)</lastBuildDate>(\\t*)(\\n*)")), QLatin1String(""));
 
           fileTmpRss.close();
           fileTmpRss.remove();
@@ -324,14 +324,14 @@ QString utils::parseDistroNews()
   }
 
   QString rssPath = QDir::homePath() + QDir::separator() + ".config/octopi/distro_rss.xml";
-  QDomDocument doc("rss");
+  QDomDocument doc(QStringLiteral("rss"));
   int itemCounter=0;
 
   QFile file(rssPath);
-  if (!file.open(QIODevice::ReadOnly)) return "";
+  if (!file.open(QIODevice::ReadOnly)) return QLatin1String("");
   if (!doc.setContent(&file)) {
       file.close();
-      return "";
+      return QLatin1String("");
   }
   file.close();
 
@@ -344,7 +344,7 @@ QString utils::parseDistroNews()
 
     if(!e.isNull())
     {
-      if(e.tagName() == "item")
+      if(e.tagName() == QLatin1String("item"))
       {
         //Let's iterate over the 10 lastest "item" news
         if (itemCounter == 10) break;
@@ -361,25 +361,25 @@ QString utils::parseDistroNews()
 
           if(!eText.isNull())
           {
-            if (eText.tagName() == "title")
+            if (eText.tagName() == QLatin1String("title"))
             {
               itemTitle = "<h3>" + eText.text() + "</h3>";
             }
-            else if (eText.tagName() == "link")
+            else if (eText.tagName() == QLatin1String("link"))
             {
               itemLink = Package::makeURLClickable(eText.text());
-              if (UnixCommand::getLinuxDistro() == ectn_MANJAROLINUX) itemLink += "<br>";
+              if (UnixCommand::getLinuxDistro() == ectn_MANJAROLINUX) itemLink += QLatin1String("<br>");
             }
-            else if (eText.tagName() == "description")
+            else if (eText.tagName() == QLatin1String("description"))
             {
               itemDescription = eText.text();
-              itemDescription += "<br>";
+              itemDescription += QLatin1String("<br>");
             }
-            else if (eText.tagName() == "pubDate")
+            else if (eText.tagName() == QLatin1String("pubDate"))
             {
               itemPubDate = eText.text();
-              itemPubDate = itemPubDate.remove(QRegularExpression("\\n"));
-              int pos = itemPubDate.indexOf("+");
+              itemPubDate = itemPubDate.remove(QRegularExpression(QStringLiteral("\\n")));
+              int pos = itemPubDate.indexOf(QLatin1String("+"));
 
               if (pos > -1)
               {
@@ -399,7 +399,7 @@ QString utils::parseDistroNews()
     n = n.nextSibling();
   }
 
-  html += "</ul>";
+  html += QLatin1String("</ul>");
   //html = html.replace("<a href=", "<a style=\"color:'" + QGuiApplication::palette().link().color().name() + "'\" href=");
 
   return html;
@@ -449,12 +449,12 @@ void utils::writeToTextBrowser(QTextBrowser* text, const QString &str, TreatURLL
 
     QString newStr = str;
 
-    if(newStr.contains("removing ") ||
-       newStr.contains("could not ") ||
-       newStr.contains("error:", Qt::CaseInsensitive) ||
-       newStr.contains("failed") ||
-       newStr.contains("is not synced") ||
-       newStr.contains("could not be found") ||
+    if(newStr.contains(QLatin1String("removing ")) ||
+       newStr.contains(QLatin1String("could not ")) ||
+       newStr.contains(QLatin1String("error:"), Qt::CaseInsensitive) ||
+       newStr.contains(QLatin1String("failed")) ||
+       newStr.contains(QLatin1String("is not synced")) ||
+       newStr.contains(QLatin1String("could not be found")) ||
        newStr.contains(StrConstants::getCommandFinishedWithErrors()))
     {
       newStr = "<b><font color=\"#E55451\">" + newStr + "&nbsp;</font></b>"; //RED
@@ -568,7 +568,7 @@ void utils::searchBarFindPreviousInTextBrowser(QTextBrowser *tb, SearchBar *sb)
 void utils::searchBarClosedInTextBrowser(QTextBrowser *tb, SearchBar *sb)
 {
   QTextCursor tc = tb->textCursor();
-  searchBarTextChangedInTextBrowser(tb, sb, "");
+  searchBarTextChangedInTextBrowser(tb, sb, QLatin1String(""));
   tc.clearSelection();
   tb->setTextCursor(tc);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -112,8 +112,8 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
 {
   LinuxDistro distro = UnixCommand::getLinuxDistro();
   QString res;
-  QString tmpRssPath = QDir::homePath() + QDir::separator() + ".config/octopi/.tmp_distro_rss.xml";
-  QString rssPath = QDir::homePath() + QDir::separator() + ".config/octopi/distro_rss.xml";
+  QString tmpRssPath = QDir::homePath() + QDir::separator() + QLatin1String(".config/octopi/.tmp_distro_rss.xml");
+  QString rssPath = QDir::homePath() + QDir::separator() + QLatin1String(".config/octopi/distro_rss.xml");
   QString contentsRss;
 
   QFile fileRss(rssPath);
@@ -177,13 +177,13 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
       {
         fileTmpRss.rename(tmpRssPath, rssPath);
 
-        if (!fileRss.open(QIODevice::ReadOnly | QIODevice::Text)) return("");
+        if (!fileRss.open(QIODevice::ReadOnly | QIODevice::Text)) return(QLatin1String(""));
         QTextStream in2(&fileRss);
         contentsRss = in2.readAll();
         contentsRss = contentsRss.remove(QRegularExpression(QStringLiteral("^\\s*")));
         fileRss.close();
         fileRss.remove();
-        if (!fileRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
+        if (!fileRss.open(QIODevice::WriteOnly | QIODevice::Text)) return(QLatin1String(""));
         in2 << contentsRss;
         in2.flush();
 
@@ -194,7 +194,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
           contentsRss.replace(QRegularExpression(QStringLiteral("(\\t*)(\\n*)<lastBuildDate>(.*)</lastBuildDate>(\\t*)(\\n*)")), QLatin1String(""));
           fileRss.close();
           fileRss.remove();
-          if (!fileRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
+          if (!fileRss.open(QIODevice::WriteOnly | QIODevice::Text)) return(QLatin1String(""));
           in2 << contentsRss;
           in2.flush();
         }
@@ -210,13 +210,13 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
         QString contentsTmpRss;
 
         //QFile fileTmpRss(tmpRssPath);
-        if (!fileTmpRss.open(QIODevice::ReadOnly | QIODevice::Text)) return("");
+        if (!fileTmpRss.open(QIODevice::ReadOnly | QIODevice::Text)) return(QLatin1String(""));
         QTextStream in(&fileTmpRss);
         contentsTmpRss = in.readAll();
         contentsTmpRss = contentsTmpRss.remove(QRegularExpression(QStringLiteral("^\\s*")));
         fileTmpRss.close();
         fileTmpRss.remove();
-        if (!fileTmpRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
+        if (!fileTmpRss.open(QIODevice::WriteOnly | QIODevice::Text)) return(QLatin1String(""));
         in << contentsTmpRss;
         in.flush();
 
@@ -227,21 +227,21 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
 
           fileTmpRss.close();
           fileTmpRss.remove();
-          if (!fileTmpRss.open(QIODevice::WriteOnly | QIODevice::Text)) return("");
+          if (!fileTmpRss.open(QIODevice::WriteOnly | QIODevice::Text)) return(QLatin1String(""));
           in << contentsTmpRss;
           in.flush();
         }
 
         fileTmpRss.close();
 
-        tmpRssSHA1 = QCryptographicHash::hash(contentsTmpRss.toLatin1(), QCryptographicHash::Sha1);
-        rssSHA1 = QCryptographicHash::hash(contentsRss.toLatin1(), QCryptographicHash::Sha1);
+        tmpRssSHA1 = QString::fromUtf8(QCryptographicHash::hash(contentsTmpRss.toLatin1(), QCryptographicHash::Sha1));
+        rssSHA1 = QString::fromUtf8(QCryptographicHash::hash(contentsRss.toLatin1(), QCryptographicHash::Sha1));
 
         if (tmpRssSHA1 != rssSHA1){
           fileRss.remove();
           fileTmpRss.rename(tmpRssPath, rssPath);
 
-          res = "*" + contentsTmpRss; //The asterisk indicates there is a MORE updated rss!
+          res = QLatin1String("*") + contentsTmpRss; //The asterisk indicates there is a MORE updated rss!
         }
         else
         {
@@ -262,15 +262,15 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
     }
     else if (searchForLatestNews)
     {
-      res = "<h3><font color=\"#E55451\">" + StrConstants::getInternetUnavailableError() + "</font></h3>";
+      res = QLatin1String("<h3><font color=\"#E55451\">") + StrConstants::getInternetUnavailableError() + QLatin1String("</font></h3>");
     }
     else if (distro != ectn_UNKNOWN)
     {
-      res = "<h3><font color=\"#E55451\">" + StrConstants::getNewsErrorMessage() + "</font></h3>";
+      res = QLatin1String("<h3><font color=\"#E55451\">") + StrConstants::getNewsErrorMessage() + QLatin1String("</font></h3>");
     }
     else
     {
-      res = "<h3><font color=\"#E55451\">" + StrConstants::getIncompatibleLinuxDistroError() + "</font></h3>";
+      res = QLatin1String("<h3><font color=\"#E55451\">") + StrConstants::getIncompatibleLinuxDistroError() + QLatin1String("</font></h3>");
     }
   }
 
@@ -292,27 +292,27 @@ QString utils::parseDistroNews()
   }*/
   if (distro == ectn_ARCHLINUX || distro == ectn_ARCHBANGLINUX /*|| distro == ectn_SWAGARCH*/)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getArchLinuxNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getArchLinuxNews() + QLatin1String("</h2></p><ul>");
   }
   else if (distro == ectn_CHAKRA)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getChakraNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getChakraNews() + QLatin1String("</h2></p><ul>");
   }
   else if (distro == ectn_CONDRESOS)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getCondresOSNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getCondresOSNews() + QLatin1String("</h2></p><ul>");
   }
   else if (distro == ectn_ENDEAVOUROS)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getEndeavourOSNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getEndeavourOSNews() + QLatin1String("</h2></p><ul>");
   }
   else if (distro == ectn_KAOS)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getKaOSNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getKaOSNews() + QLatin1String("</h2></p><ul>");
   }
   else if (distro == ectn_MANJAROLINUX)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getManjaroLinuxNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getManjaroLinuxNews() + QLatin1String("</h2></p><ul>");
   }
   /*else if (distro == ectn_NETRUNNER)
   {
@@ -320,10 +320,10 @@ QString utils::parseDistroNews()
   }*/
   else if (distro == ectn_PARABOLA)
   {
-    html = "<p align=\"center\"><h2>" + StrConstants::getParabolaNews() + "</h2></p><ul>";
+    html = QLatin1String("<p align=\"center\"><h2>") + StrConstants::getParabolaNews() + QLatin1String("</h2></p><ul>");
   }
 
-  QString rssPath = QDir::homePath() + QDir::separator() + ".config/octopi/distro_rss.xml";
+  QString rssPath = QDir::homePath() + QDir::separator() + QLatin1String(".config/octopi/distro_rss.xml");
   QDomDocument doc(QStringLiteral("rss"));
   int itemCounter=0;
 
@@ -363,7 +363,7 @@ QString utils::parseDistroNews()
           {
             if (eText.tagName() == QLatin1String("title"))
             {
-              itemTitle = "<h3>" + eText.text() + "</h3>";
+              itemTitle = QLatin1String("<h3>") + eText.text() + QLatin1String("</h3>");
             }
             else if (eText.tagName() == QLatin1String("link"))
             {
@@ -383,7 +383,7 @@ QString utils::parseDistroNews()
 
               if (pos > -1)
               {
-                itemPubDate = itemPubDate.mid(0, pos-1).trimmed() + "<br>";
+                itemPubDate = itemPubDate.mid(0, pos-1).trimmed() + QLatin1String("<br>");
               }
             }
           }
@@ -391,7 +391,7 @@ QString utils::parseDistroNews()
           text = text.nextSibling();
         }
 
-        html += "<li><p>" + itemTitle + " " + itemPubDate + "<br>" + itemLink + itemDescription + "</p></li>";
+        html += QLatin1String("<li><p>") + itemTitle + QLatin1Char(' ') + itemPubDate + QLatin1String("<br>") + itemLink + itemDescription + QLatin1String("</p></li>");
         itemCounter++;
       }
     }
@@ -457,7 +457,7 @@ void utils::writeToTextBrowser(QTextBrowser* text, const QString &str, TreatURLL
        newStr.contains(QLatin1String("could not be found")) ||
        newStr.contains(StrConstants::getCommandFinishedWithErrors()))
     {
-      newStr = "<b><font color=\"#E55451\">" + newStr + "&nbsp;</font></b>"; //RED
+      newStr = QLatin1String("<b><font color=\"#E55451\">") + newStr + QLatin1String("&nbsp;</font></b>"); //RED
     }
 
     if(treatURLLinks == ectn_TREAT_URL_LINK)

--- a/src/wmhelper.cpp
+++ b/src/wmhelper.cpp
@@ -49,10 +49,10 @@ bool WMHelper::isKDERunning(){
 bool WMHelper::isTDERunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-C";
+  slParam << QStringLiteral("-C");
   slParam << ctn_TDE_DESKTOP;
 
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
 
@@ -71,10 +71,10 @@ bool WMHelper::isTDERunning(){
 bool WMHelper::isXFCERunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-C";
+  slParam << QStringLiteral("-C");
   slParam << ctn_XFCE_DESKTOP;
 
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
   QString out = proc.readAll();
@@ -92,10 +92,10 @@ bool WMHelper::isXFCERunning(){
 bool WMHelper::isLXDERunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-C";
+  slParam << QStringLiteral("-C");
   slParam << ctn_LXDE_DESKTOP;
 
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
   QString out = proc.readAll();
@@ -121,10 +121,10 @@ bool WMHelper::isLXQTRunning()
 bool WMHelper::isOPENBOXRunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-C";
+  slParam << QStringLiteral("-C");
   slParam << ctn_OPENBOX_DESKTOP;
 
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
   QString out = proc.readAll();
@@ -142,10 +142,10 @@ bool WMHelper::isOPENBOXRunning(){
 bool WMHelper::isMATERunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-C";
+  slParam << QStringLiteral("-C");
   slParam << ctn_MATE_DESKTOP;
 
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
   QString out = proc.readAll();
@@ -163,10 +163,10 @@ bool WMHelper::isMATERunning(){
 bool WMHelper::isCinnamonRunning(){
   QStringList slParam;
   QProcess proc;
-  slParam << "-fC";
+  slParam << QStringLiteral("-fC");
   slParam << ctn_CINNAMON_DESKTOP;
 
-  proc.start("ps", slParam);
+  proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
   QString out = proc.readAll();
@@ -184,7 +184,7 @@ bool WMHelper::isCinnamonRunning(){
 bool WMHelper::isLuminaRunning()
 {
   QProcess proc;
-  proc.start("ps -A -o command");
+  proc.start(QStringLiteral("ps -A -o command"));
   proc.waitForStarted();
   proc.waitForFinished();
   QString out = proc.readAll();
@@ -211,7 +211,7 @@ QString WMHelper::getXFCEEditor(){
  */
 QString WMHelper::getOctopiSudoCommand(){
   QString result = ctn_OCTOPISUDO;
-  result += " -d ";
+  result += QLatin1String(" -d ");
 
   return result;
 }
@@ -243,7 +243,7 @@ QString WMHelper::getSUCommand(){
  */
 QString WMHelper::getSUTool()
 {
-  QString result("");
+  QString result(QLatin1String(""));
 
   if (UnixCommand::hasTheExecutable(ctn_OCTOPISUDO)){
     return ctn_OCTOPISUDO;
@@ -264,7 +264,7 @@ QString WMHelper::getKDEOpenHelper(){
   else if (UnixCommand::hasTheExecutable(ctn_KDE5_OPEN))
     return ctn_KDE5_OPEN;
   else
-    return "NONE";
+    return QStringLiteral("NONE");
 }
 
 /*
@@ -298,7 +298,7 @@ void WMHelper::openFile(const QString& fileName){
     p->startDetached( ctn_XFCE_FILE_MANAGER, s );
   }
   else if (isKDERunning() && UnixCommand::hasTheExecutable(ctn_KDE_FILE_MANAGER)){
-    s << "exec";
+    s << QStringLiteral("exec");
     s << "file:" + fileToOpen;
     p->startDetached( ctn_KDE_FILE_MANAGER, s );
   }
@@ -307,7 +307,7 @@ void WMHelper::openFile(const QString& fileName){
     p->startDetached( getKDEOpenHelper(), s );
   }
   else if (isTDERunning() && UnixCommand::hasTheExecutable(ctn_TDE_FILE_MANAGER)){
-    s << "exec";
+    s << QStringLiteral("exec");
     s << "file:" + fileToOpen;
     p->startDetached( ctn_TDE_FILE_MANAGER, s );
   }
@@ -442,7 +442,7 @@ void WMHelper::openDirectory( const QString& dirName ){
       }
       else if (UnixCommand::hasTheExecutable(ctn_KDE_FILE_MANAGER))
       {
-        s << "newTab";
+        s << QStringLiteral("newTab");
         s << dir;
         p->startDetached( ctn_KDE_FILE_MANAGER, s );
       }
@@ -451,7 +451,7 @@ void WMHelper::openDirectory( const QString& dirName ){
     {
       if (UnixCommand::hasTheExecutable(ctn_TDE_FILE_MANAGER))
       {
-        s << "newTab";
+        s << QStringLiteral("newTab");
         s << dir;
         p->startDetached( ctn_TDE_FILE_MANAGER, s );
       }

--- a/src/wmhelper.cpp
+++ b/src/wmhelper.cpp
@@ -56,7 +56,7 @@ bool WMHelper::isTDERunning(){
   proc.waitForStarted();
   proc.waitForFinished();
 
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_TDE_DESKTOP)>0)
@@ -77,7 +77,7 @@ bool WMHelper::isXFCERunning(){
   proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_XFCE_DESKTOP)>0)
@@ -98,7 +98,7 @@ bool WMHelper::isLXDERunning(){
   proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_LXDE_DESKTOP)>0)
@@ -127,7 +127,7 @@ bool WMHelper::isOPENBOXRunning(){
   proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_OPENBOX_DESKTOP)>0)
@@ -148,7 +148,7 @@ bool WMHelper::isMATERunning(){
   proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_MATE_DESKTOP)>0)
@@ -169,7 +169,7 @@ bool WMHelper::isCinnamonRunning(){
   proc.start(QStringLiteral("ps"), slParam);
   proc.waitForStarted();
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_CINNAMON_DESKTOP)>0)
@@ -187,7 +187,7 @@ bool WMHelper::isLuminaRunning()
   proc.start(QStringLiteral("ps -A -o command"));
   proc.waitForStarted();
   proc.waitForFinished();
-  QString out = proc.readAll();
+  QString out = QString::fromUtf8(proc.readAll());
   proc.close();
 
   if (out.count(ctn_LUMINA_DESKTOP)>0)
@@ -299,7 +299,7 @@ void WMHelper::openFile(const QString& fileName){
   }
   else if (isKDERunning() && UnixCommand::hasTheExecutable(ctn_KDE_FILE_MANAGER)){
     s << QStringLiteral("exec");
-    s << "file:" + fileToOpen;
+    s << QLatin1String("file:") + fileToOpen;
     p->startDetached( ctn_KDE_FILE_MANAGER, s );
   }
   else if ((isKDERunning()) && UnixCommand::hasTheExecutable(ctn_KDE4_FILE_MANAGER)){
@@ -308,7 +308,7 @@ void WMHelper::openFile(const QString& fileName){
   }
   else if (isTDERunning() && UnixCommand::hasTheExecutable(ctn_TDE_FILE_MANAGER)){
     s << QStringLiteral("exec");
-    s << "file:" + fileToOpen;
+    s << QLatin1String("file:") + fileToOpen;
     p->startDetached( ctn_TDE_FILE_MANAGER, s );
   }
   else if (isMATERunning() && UnixCommand::hasTheExecutable(ctn_MATE_EDITOR)){
@@ -358,44 +358,44 @@ void WMHelper::editFile( const QString& fileName, EditOptions opt ){
   LinuxDistro distro = UnixCommand::getLinuxDistro();
   if (distro == ectn_ARCHBANGLINUX && UnixCommand::hasTheExecutable(ctn_ARCHBANG_EDITOR))
   {
-    p = ctn_ARCHBANG_EDITOR + " " + fileName;
+    p = ctn_ARCHBANG_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (isXFCERunning() && (UnixCommand::hasTheExecutable(ctn_XFCE_EDITOR) ||
                                UnixCommand::hasTheExecutable(ctn_XFCE_EDITOR_ALT))){
-    p = getXFCEEditor() + " " + fileName;
+    p = getXFCEEditor() + QLatin1Char(' ') + fileName;
   }
   else if (isKDERunning() && UnixCommand::hasTheExecutable(ctn_KDE_EDITOR)){
-    p += ctn_KDE_EDITOR + " " + fileName;
+    p += ctn_KDE_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (isKDERunning() && UnixCommand::hasTheExecutable(ctn_KDE4_EDITOR)){
-    p += ctn_KDE4_EDITOR + " " + fileName;
+    p += ctn_KDE4_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (isTDERunning() && UnixCommand::hasTheExecutable(ctn_TDE_EDITOR)){
-    p += ctn_TDE_EDITOR + " " + fileName;
+    p += ctn_TDE_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (isMATERunning() && UnixCommand::hasTheExecutable(ctn_MATE_EDITOR)){
-    p = ctn_MATE_EDITOR + " " + fileName;
+    p = ctn_MATE_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (isLXQTRunning() && UnixCommand::hasTheExecutable(ctn_LXQT_EDITOR)){
-    p = ctn_LXQT_EDITOR + " " + fileName;
+    p = ctn_LXQT_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (isLuminaRunning() && UnixCommand::hasTheExecutable(ctn_LUMINA_EDITOR)){
-    p += ctn_LUMINA_EDITOR + " " + fileName;
+    p += ctn_LUMINA_EDITOR + QLatin1Char(' ') + fileName;
   }
   if (UnixCommand::hasTheExecutable(ctn_ARCHBANG_EDITOR))
   {
-    p = ctn_ARCHBANG_EDITOR + " " + fileName;
+    p = ctn_ARCHBANG_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (UnixCommand::hasTheExecutable(ctn_CINNAMON_EDITOR)){
-    p = ctn_CINNAMON_EDITOR + " " + fileName;
+    p = ctn_CINNAMON_EDITOR + QLatin1Char(' ') + fileName;
   }
   else if (UnixCommand::hasTheExecutable(ctn_XFCE_EDITOR) || UnixCommand::hasTheExecutable(ctn_XFCE_EDITOR_ALT)){
-    p = getXFCEEditor() + " " + fileName;
+    p = getXFCEEditor() + QLatin1Char(' ') + fileName;
   }
 
   if (opt == ectn_EDIT_AS_NORMAL_USER)
   {
-    process->startDetached("/bin/sh -c \"" + p + "\"");
+    process->startDetached(QLatin1String("/bin/sh -c \"") + p + QLatin1Char('"'));
   }
   else
   {


### PR DESCRIPTION
Reduce the number of unneeded memory allocations.
Make the conversions explicit.
Done automatically by Clazy. The remaining cases will be done by hand.