### PR TITLE
Use Garuda forum announcement feed for distro news

### DIFF
--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -368,7 +368,7 @@ QString SettingsManager::getDistroRSSUrl()
   SettingsManager p_instance;
   LinuxDistro distro = UnixCommand::getLinuxDistro();
 
-  if (distro == ectn_ARCHLINUX || distro == ectn_ARCHBANGLINUX || distro == ectn_ARCHCRAFT || distro == ectn_GARUDALINUX)
+  if (distro == ectn_ARCHLINUX || distro == ectn_ARCHBANGLINUX || distro == ectn_ARCHCRAFT)
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://archlinux.org/feeds/news/"))).toString();
   else if (distro == ectn_ARTIXLINUX)
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://artixlinux.org/feed.php"))).toString();
@@ -378,6 +378,8 @@ QString SettingsManager::getDistroRSSUrl()
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://condresos.codelinsoft.it/index.php/blog?format=feed&amp;type=rss"))).toString();
   else if (distro == ectn_ENDEAVOUROS)
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://endeavouros.com/feed/"))).toString();
+  else if (distro == ectn_GARUDALINUX)
+    return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://forum.garudalinux.org/c/announcements/16.rss"))).toString();
   else if (distro == ectn_KAOS)
     return (p_instance.getSYSsettings()->value(ctn_KEY_DISTRO_RSS_URL, QStringLiteral("https://kaosx.us/feed.xml"))).toString();
   else if (distro == ectn_MANJAROLINUX)


### PR DESCRIPTION
Currently Octopi displays Arch Linux news in the feed for Garuda Linux. Displaying our dedicated announcement category of our forum would be better as there are potential posts which might be important for users.