### PR TITLE
Add getIconOptions icon for Options menu

### DIFF
--- a/src/mainwindow_init.cpp
+++ b/src/mainwindow_init.cpp
@@ -709,6 +709,7 @@ void MainWindow::initActions()
 
   m_actionMenuOptions->setText(StrConstants::getOptions());
   m_actionMenuOptions->setIcon(IconHelper::getIconOptions());
+  
   connect(m_actionMenuOptions, SIGNAL(triggered()), this, SLOT(onOptions()));
 
   m_actionStopTransaction = new QAction(this);

--- a/src/mainwindow_init.cpp
+++ b/src/mainwindow_init.cpp
@@ -708,6 +708,7 @@ void MainWindow::initActions()
   ui->actionOpenRootTerminal->setVisible(false);
 
   m_actionMenuOptions->setText(StrConstants::getOptions());
+  m_actionMenuOptions->setIcon(IconHelper::getIconOptions());
   connect(m_actionMenuOptions, SIGNAL(triggered()), this, SLOT(onOptions()));
 
   m_actionStopTransaction = new QAction(this);


### PR DESCRIPTION
Uses IconHelper::getIconOptions for Options menu entry

![Screenshot_20211121_164100](https://user-images.githubusercontent.com/43704682/142785848-dbc34505-e7a6-4894-85ea-662c748133c1.png)
