### PR TITLE
Make curl follow redirect (301) for news feed

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -130,7 +130,7 @@ QString utils::retrieveDistroNews(bool searchForLatestNews)
 
   if(searchForLatestNews && UnixCommand::hasInternetConnection() && distro != ectn_UNKNOWN)
   {    
-    QString curlCommand = QStringLiteral("%1 -o %2");
+    QString curlCommand = QStringLiteral("%1 -o %2 -L");
     QStringList curlParams;
     QString distroRSSUrl = SettingsManager::getDistroRSSUrl();
 


### PR DESCRIPTION
Fix 301 Moved Permanently bug on News tab.
