### PR TITLE
Mark as single window app

### DIFF
--- a/octopi.desktop
+++ b/octopi.desktop
@@ -147,3 +147,5 @@ X-DBUS-ServiceName=
 X-DBUS-StartupType=
 X-KDE-SubstituteUID=false
 X-KDE-Username=
+Version=1.5
+SingleMainWindow=true


### PR DESCRIPTION
There can only be one main window at a time, mark it as such in the desktop file

That way desktop environments know to not offer to open a second window