### PR TITLE
fix typo

### DIFF
--- a/src/pacmanexec.cpp
+++ b/src/pacmanexec.cpp
@@ -951,7 +951,7 @@ QStringList PacmanExec::getDotPacnewFileList()
 }
 
 /*
- * Calls mirro-check to check mirrors and returns output to UI
+ * Calls mirror-check to check mirrors and returns output to UI
  */
 void PacmanExec::doMirrorCheck()
 {


### PR DESCRIPTION
This fixes a typo in a comment.

I found this while looking through the source, checking why mirror-check is only used for KaOS.

Being only packaged by it, is it automatically detected?

I try to make it work for normal Arch. 