### PR TITLE
fixed silent fail when pacman running

### DIFF
--- a/cachecleaner/packagegroupmodel.cpp
+++ b/cachecleaner/packagegroupmodel.cpp
@@ -158,7 +158,11 @@ bool PackageGroupModel::isSUAvailable()
  */
 void PackageGroupModel::cleanCache()
 {
-  if (isExecutingCommand || UnixCommand::isPacmanDbLocked()) return;
+  if (isExecutingCommand || UnixCommand::isPacmanDbLocked()){
+    QMessageBox::critical( nullptr, StrConstants::getApplicationName(),
+                           StrConstants::getErrorDbLock());
+    return;
+  }
 
   if (!isSUAvailable())
     return;

--- a/src/strconstants.cpp
+++ b/src/strconstants.cpp
@@ -700,6 +700,11 @@ QString StrConstants::getErrorNoSuCommand(){
     QObject::tr("There are no means to get administrator's credentials.");
 }
 
+QString StrConstants::getErrorDbLock(){
+  return
+    QObject::tr("Pacman is running or didn't cleanly close (/var/lib/pacman/db.lck exists!)");
+}
+
 QString StrConstants::getYoullNeedSuFrontend(){
   return QObject::tr("You'll need to install \"octopi-sudo\" in order to use Octopi.");
 }

--- a/src/strconstants.h
+++ b/src/strconstants.h
@@ -173,6 +173,7 @@ public:
   static QString getCancelActionsConfirmation();
   static QString getEnterAdministratorsPassword();
   static QString getErrorNoSuCommand();
+  static QString getErrorDbLock();
   static QString getYoullNeedSuFrontend();
   static QString getYoullNeedToInstallAURTool();
   static QString getDoYouWantToInstallYayTool();


### PR DESCRIPTION
I'm a newbie, but I was updating my install when I noticed that I didn't have enough space, so I opened octopi-cache-cleaner but when I clicked Clean 4.0GiB it silently failed, I looked at the source to add a error when pacman is running or db.lck .