### PR TITLE
PKGBUILD: make it truly a VCS PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,8 @@
-pkgname=octopi
-pkgver=0.15.0
+_pkgname=octopi
+pkgname=octopi-git
+pkgver=0.15.0.r15.g69e85dd
 pkgrel=1
-pkgdesc="This is Octopi, a powerful Pacman frontend using Qt libs"
+pkgdesc="This is Octopi, a powerful Pacman frontend using Qt libs (git checkout)"
 url="https://tintaescura.com/projects/octopi/"
 arch=('i686' 'x86_64')
 license=('GPL2')
@@ -12,16 +13,21 @@ source=("git+https://github.com/aarnt/octopi.git")
 md5sums=('SKIP')
 
 prepare() {
-   cd "${pkgname}"
+   cd "${_pkgname}"
    
    # enable the kstatus switch, disable if you wish to build without Plasma/knotifications support
    sed -e "s|DEFINES += OCTOPI_EXTENSIONS ALPM_BACKEND #KSTATUS|DEFINES += OCTOPI_EXTENSIONS ALPM_BACKEND KSTATUS|" -i notifier/octopi-notifier.pro
       
    cp resources/images/octopi_green.png resources/images/octopi.png
 }
+
+pkgver() {
+   cd "${_pkgname}"
+   git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//'
+}
          
 build() {
-   cd "${pkgname}"
+   cd "${_pkgname}"
    echo "Starting build..."   
    qmake-qt5 PREFIX=/usr QMAKE_CFLAGS="${CFLAGS}" QMAKE_CXXFLAGS="${CXXFLAGS}" QMAKE_LFLAGS="${LDFLAGS}" octopi.pro
    make
@@ -38,7 +44,7 @@ build() {
 }
 
 package() {
-   cd "${pkgname}"
+   cd "${_pkgname}"
    make INSTALL_ROOT="${pkgdir}" install
 
    _subdirs="cachecleaner helper notifier repoeditor"


### PR DESCRIPTION
Before these changes the PKGBUILD suggest in its name and pkgver that it would build a specific version. In reality it would build latest master.
To make it clear and get a more meaningful pkgver for the built package add pkgver() and rename the created package. These changes adopt the VCS packaging guidelines for Arch Linux: https://wiki.archlinux.org/title/VCS_package_guidelines
___________
Another approach would be to build the specified tag: https://github.com/Narrat/octopi/commit/804544157f47a8f3bb4e1abb63658a3b3b8868d2
I opted for the VCS approach, as this PKGBUILD is located within the source repo and I assumed the intention is to get quickly a package for installation to test some changes.
Note that the source line uses the release archive. It could also be changed to use the tag: `${pkgname}-${pkgver}.tar.gz::https://github.com/aarnt/octopi/archive/refs/tags/v${pkgver}.tar.gz` (which should also be used for the PKGBUILD hosted on the aurweb as omitting the pkgver (and to an extend the extension) in the downloaded source causes issues for users of SRCDEST as the name isn't unique)