### PR TITLE
Show current version of the packages on the System Upgrade window

### DIFF
--- a/notifier/mainwindow.h
+++ b/notifier/mainwindow.h
@@ -118,6 +118,7 @@ private:
   QAction *m_actionAbout;
   QAction *m_actionExit;
   QIcon m_icon;
+  QHash<QString, QString> *m_checkUpdatesNameCurrentVersion;
   QHash<QString, QString> *m_checkUpdatesNameNewVersion;
   QStringList m_checkUpdatesStringList;
   QStringList *m_outdatedStringList;

--- a/src/package.h
+++ b/src/package.h
@@ -37,7 +37,7 @@ struct PackageListData{
   QString repository;
   QString version;
   QString description;
-  QString outatedVersion;
+  QString outdatedVersion;
   double  downloadSize;
   double installedSize;
   double buildDate;
@@ -61,11 +61,20 @@ struct PackageListData{
                                     status(ectn_NON_INSTALLED){
   }
 
+  PackageListData(QString n, QString outdatedVersion, QString v, QString dSize) 
+                                    : name(n),
+                                    version(v),
+                                    outdatedVersion(outdatedVersion.trimmed()),
+                                    downloadSize(QString(dSize).toDouble()),
+                                    popularity(0),
+                                    status(ectn_NON_INSTALLED){
+  }
+
   PackageListData(QString n, QString r, QString v, PackageStatus pkgStatus, QString outVersion=QLatin1String(""))
                                     : name(n),
                                     repository(r),
                                     version(v),
-                                    outatedVersion(outVersion.trimmed()),
+                                    outdatedVersion(outVersion.trimmed()),
                                     downloadSize(0.0),
                                     popularity(0),
                                     status(pkgStatus){
@@ -77,7 +86,7 @@ struct PackageListData{
                                     repository(r),
                                     version(v),
                                     description(d),
-                                    outatedVersion(outVersion.trimmed()),
+                                    outdatedVersion(outVersion.trimmed()),
                                     downloadSize(downSize),
                                     popularity(0),
                                     status(pkgStatus){
@@ -90,7 +99,7 @@ struct PackageListData{
                                     repository(r),
                                     version(v),
                                     description(d),
-                                    outatedVersion(outVersion.trimmed()),
+                                    outdatedVersion(outVersion.trimmed()),
                                     downloadSize(downSize),
                                     installedSize(instSize),
                                     buildDate(bDate),
@@ -106,7 +115,7 @@ struct PackageListData{
                                     repository(r),
                                     version(v),
                                     description(d),
-                                    outatedVersion(outVersion.trimmed()),
+                                    outdatedVersion(outVersion.trimmed()),
                                     downloadSize(0.0),
                                     popularity(0),
                                     status(pkgStatus){
@@ -118,7 +127,7 @@ struct PackageListData{
                                     repository(r),
                                     version(v),
                                     description(d),
-                                    outatedVersion(outVersion.trimmed()),
+                                    outdatedVersion(outVersion.trimmed()),
                                     downloadSize(0.0),
                                     installedSize(instSize),
                                     buildDate(bDate),

--- a/src/packagerepository.cpp
+++ b/src/packagerepository.cpp
@@ -165,11 +165,11 @@ void PackageRepository::setOutdatedData(const QHash<QString, QString> &outdatedP
       pld->status=ectn_OUTDATED;
       pld->name=(*it)->name;
       pld->description=(*it)->description;
-      pld->outatedVersion=(*it)->version;
+      pld->outdatedVersion=(*it)->version;
       pld->version=outdatedPackages.value((*it)->name);
 
-      if (pld->version == pld->outatedVersion)
-        pld->outatedVersion=(*it)->outdatedVersion;
+      if (pld->version == pld->outdatedVersion)
+        pld->outdatedVersion=(*it)->outdatedVersion;
 
       pld->repository=(*it)->repository;
       pld->downloadSize=(*it)->downloadSize;
@@ -385,11 +385,11 @@ PackageRepository::PackageData::PackageData(const PackageListData& pkg, const bo
   : required(isRequired), managedByAUR(isManagedByAUR), name(pkg.name),
     repository(pkg.repository.isEmpty() ? StrConstants::getForeignRepositoryName() : pkg.repository),
     version(pkg.version), description(pkg.description), // octopi wants it converted to utf8
-    outdatedVersion(pkg.outatedVersion), downloadSize(pkg.downloadSize), installedSize(pkg.installedSize),
+    outdatedVersion(pkg.outdatedVersion), downloadSize(pkg.downloadSize), installedSize(pkg.installedSize),
     buildDate(pkg.buildDate), installDate(pkg.installDate), license(pkg.license), installReason(pkg.installReason),
     status(pkg.status != ectn_OUTDATED ?
            pkg.status :
-           (Package::alpm_pkg_vercmp(pkg.outatedVersion.toLatin1().data(), pkg.version.toLatin1().data()) == 1 ?
+           (Package::alpm_pkg_vercmp(pkg.outdatedVersion.toLatin1().data(), pkg.version.toLatin1().data()) == 1 ?
              ectn_NEWER : ectn_OUTDATED)),
     popularity(isManagedByAUR ? pkg.popularity : -1),
     popularityString(isManagedByAUR ? QString::number(pkg.popularity) : QString())

--- a/src/pacmanexec.cpp
+++ b/src/pacmanexec.cpp
@@ -819,12 +819,12 @@ void PacmanExec::onReadOutput()
     if (!output.isEmpty())
     {
       //checkupdates outputs outdated packages like this: "apr 1.6.5-1 -> 1.7.0-1"
-      if (m_listOfOutatedPackages.count() == 0)
-        m_listOfOutatedPackages = output.split(QStringLiteral("\n"), Qt::SkipEmptyParts);
+      if (m_listOfOutdatedPackages.count() == 0)
+        m_listOfOutdatedPackages = output.split(QStringLiteral("\n"), Qt::SkipEmptyParts);
       else
       {
         //checkupdates returned more than 1 time from the QProcess event, so we have to concatenate the list...
-        QString lastPackage = m_listOfOutatedPackages.last();
+        QString lastPackage = m_listOfOutdatedPackages.last();
         QStringList newList = output.split(QStringLiteral("\n"), Qt::SkipEmptyParts);
         QString firstPackage = newList.first();
         QStringList partsLast = lastPackage.split(QStringLiteral(" "), Qt::SkipEmptyParts);
@@ -832,16 +832,16 @@ void PacmanExec::onReadOutput()
 
         if (partsLast.count()<4 || partsFirst.count()<4)
         {
-          m_listOfOutatedPackages.removeLast();          
+          m_listOfOutdatedPackages.removeLast();          
           newList.removeFirst();
           lastPackage += firstPackage;
-          m_listOfOutatedPackages.append(lastPackage);
-          m_listOfOutatedPackages.append(newList);
+          m_listOfOutdatedPackages.append(lastPackage);
+          m_listOfOutdatedPackages.append(newList);
         }
         else
         {
           newList = output.split(QStringLiteral("\n"), Qt::SkipEmptyParts);
-          m_listOfOutatedPackages.append(newList);
+          m_listOfOutdatedPackages.append(newList);
         }
       }
     }
@@ -978,7 +978,7 @@ void PacmanExec::onFinished(int exitCode, QProcess::ExitStatus es)
 void PacmanExec::doCheckUpdates()
 {
   m_commandExecuting = ectn_CHECK_UPDATES;
-  m_listOfOutatedPackages.clear();
+  m_listOfOutdatedPackages.clear();
   m_unixCommand->executeCommandAsNormalUser(ctn_CHECKUPDATES_BINARY, QStringList());
 }
 
@@ -987,7 +987,7 @@ void PacmanExec::doCheckUpdates()
  */
 QStringList PacmanExec::getOutdatedPackages()
 {
-  return m_listOfOutatedPackages;
+  return m_listOfOutdatedPackages;
 }
 
 /*

--- a/src/pacmanexec.h
+++ b/src/pacmanexec.h
@@ -48,7 +48,7 @@ private:
   CommandExecuting m_commandExecuting;
   QStringList m_lastCommandList; //run in terminal commands
   QStringList m_textPrinted;
-  QStringList m_listOfOutatedPackages;
+  QStringList m_listOfOutdatedPackages;
   QStringList m_listOfDotPacnewFiles; //contains the list of "blahblah installed as blahblah.pacnew" occurencies (if any)
 
   bool m_processWasCanceled;


### PR DESCRIPTION
When I use the system upgrade window, I don't know on which version I am currently in order to know whether the new version is just a patch or a minor/major version.

I thought adding the current version to the list of packages would give a little more context. What do you think ?

<img width="508" height="710" alt="image" src="https://github.com/user-attachments/assets/be5e3456-eb14-4610-bb3e-160ba0dac20d" />

(This is my first c++ contribution, give me any criticism pls)

I also fixed a small typo, the changes may appear larger than it really is.