### PR TITLE
Add Nix build system for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ qrc_resources.cpp
 repoeditor/.qtc_clangd/**
 repoeditor/bin/**
 repoeditor/build/**
+result
+result/**
 sudo/*.o
 sudo/moc*.*
 sudo/octopi-sudo

--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ $ make
 $ sudo make install
 ```
 
+### Steps to build Octopi source code (Nix)
+
+For development in a clean, isolated environment without installing dependencies system-wide, you can use Nix. This requires [Nix with flakes enabled](https://nixos.wiki/wiki/Flakes).
+
+```
+$ cd octopi
+$ nix develop  # or use direnv
+$ mkdir -p build && cd build
+$ cmake .. -DCMAKE_BUILD_TYPE=Release
+$ make -j$(nproc)
+$ ./octopi
+```
+
+The Nix environment provides all dependencies (`qt6`, `cmake`, `vala`, etc.) and builds `alpm_octopi_utils` and `qt-sudo` automatically. You can then follow the standard CMake or qmake build instructions above. The environment sets `OCTOPI_ALLOWED_PATHS` to allow running from the build directory.
+
 ### To run Octopi
 
 ```

--- a/cachecleaner/main.cpp
+++ b/cachecleaner/main.cpp
@@ -64,9 +64,9 @@ int main( int argc, char *argv[] )
     return (-3);
   }
 
-  if (!QFile::exists(ctn_OCTOPI_HELPER_PATH))
+  if (!QFile::exists(UnixCommand::getOctopiHelperPath()))
   {
-    qDebug() << "Aborting cache-cleaner as 'octphelper' binary could not be found! [" << ctn_OCTOPI_HELPER_PATH << "]";
+    qDebug() << "Aborting cache-cleaner as 'octphelper' binary could not be found! [" << UnixCommand::getOctopiHelperPath() << "]";
     return (-4);
   }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,112 @@
+{
+  description = "Octopi development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        alpm_octopi_utils = pkgs.stdenv.mkDerivation {
+          pname = "alpm_octopi_utils";
+          version = "unstable-2024-12-27";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "aarnt";
+            repo = "alpm_octopi_utils";
+            rev = "0ed2a8bd6b869f40683cf7a79727dc64d7da274e";
+            hash = "sha256-TxjXtdhp2BqkGDVYnyhQ5mccU0MDndFfAZMuBQRVf1c=";
+          };
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            vala
+            pkg-config
+          ];
+          buildInputs = with pkgs; [
+            pacman
+            glib
+            libarchive
+          ];
+        };
+
+        qt-sudo = pkgs.stdenv.mkDerivation {
+          pname = "qt-sudo";
+          version = "2.4.0";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "aarnt";
+            repo = "qt-sudo";
+            rev = "v2.4.0";
+            hash = "sha256-s7kRYKCgUgEScZVsyEmzSiRCUJ+30t/OIkqos8tMXo8=";
+          };
+
+          nativeBuildInputs = with pkgs; [
+            qt6.wrapQtAppsHook
+            qt6.qmake
+            qt6.qttools
+          ];
+          buildInputs = [ pkgs.qt6.qtbase ];
+
+          postConfigure = ''
+            substituteInPlace Makefile \
+              --replace-quiet "${pkgs.qt6.qtbase}/bin/lrelease" "${pkgs.qt6.qttools}/bin/lrelease"
+          '';
+        };
+      in
+      {
+        formatter = pkgs.nixfmt;
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            alpm_octopi_utils
+            cmake
+            gcc
+            git
+            glib
+            gnumake
+            kdePackages.kstatusnotifieritem
+            libarchive
+            lxqt.qtermwidget
+            pacman
+            pipewire
+            pkg-config
+            qt-sudo
+            qt6.qmake
+            qt6.qt5compat
+            qt6.qtbase
+            qt6.qtmultimedia
+            qt6.qttools
+            qt6.wrapQtAppsHook
+            vala
+          ];
+
+          env = {
+            QT_QPA_PLATFORM_PLUGIN_PATH = "${pkgs.qt6.qtbase}/${pkgs.qt6.qtbase.qtPluginPrefix}";
+            QT_PLUGIN_PATH = "${pkgs.qt6.qtbase}/${pkgs.qt6.qtbase.qtPluginPrefix}";
+          };
+
+          shellHook = ''
+            export OCTOPI_ALLOWED_PATHS="/usr/bin:$PWD/build"
+            export LD_LIBRARY_PATH="${pkgs.pipewire}/lib:$LD_LIBRARY_PATH"
+
+            # nixpkgs supplies libalpm headers for the build, but the host
+            # pacman writes the on-disk DB and the host sudo carries the
+            # setuid bit, so a small set of host tools must take priority
+            # at runtime.
+            shim_dir="$(mktemp -d -t octopi-host-shims-XXXXXX)"
+            for tool in sudo pacman fakeroot pacman-conf; do
+              [ -x "/usr/bin/$tool" ] && ln -sf "/usr/bin/$tool" "$shim_dir/$tool"
+            done
+            export PATH="$shim_dir:$PATH"
+          '';
+        };
+      }
+    );
+}

--- a/helper/octopihelper.cpp
+++ b/helper/octopihelper.cpp
@@ -23,6 +23,7 @@
 
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <dirent.h>
 
 #include <QProcess>
@@ -217,24 +218,40 @@ pid_t OctopiHelper::findPidByName(const QString &processName)
   return -1;
 }
 
+static QString readProcExe(pid_t pid)
+{
+  QString exeLink = QStringLiteral("/proc/%1/exe").arg(pid);
+  char buf[PATH_MAX];
+  ssize_t len = readlink(exeLink.toLocal8Bit().constData(), buf, sizeof(buf) - 1);
+  if (len == -1) return QString();
+  buf[len] = '\0';
+  return QFileInfo(QString::fromLocal8Bit(buf)).canonicalFilePath();
+}
+
+static bool isDirOwnerWritableOnly(const QString &dir)
+{
+  struct stat st{};
+  if (stat(dir.toLocal8Bit().constData(), &st) != 0) return false;
+  return (st.st_mode & (S_IWGRP | S_IWOTH)) == 0;
+}
+
 /*
- * Tests if the given process is running from the expected file path (/usr/bin)
+ * Trust /usr/bin (system install) or the helper's own directory if that
+ * directory is owner-writable only. The widened trust uses the same
+ * path-based model as before: filesystem permissions, not binary content.
  */
 bool OctopiHelper::isProcessRunningFromPath(pid_t pid)
 {
-  QString exeLink = QStringLiteral("/proc/%1/exe").arg(pid);
-  char actualPath[PATH_MAX];
-  ssize_t len = readlink(exeLink.toLocal8Bit().constData(), actualPath, sizeof(actualPath) - 1);
-  if (len == -1) {
-    //perror("readlink");
-    return false;
-  }
-
-  actualPath[len] = '\0';
-  QString realPath = QFileInfo(QString::fromLocal8Bit(actualPath)).canonicalFilePath();
-
+  QString realPath = readProcExe(pid);
+  if (realPath.isEmpty()) return false;
   log(QStringLiteral("Path of PID %1 is %2").arg(pid).arg(realPath));
-  return realPath.startsWith(QStringLiteral("/usr/bin"));
+
+  if (realPath.startsWith(QStringLiteral("/usr/bin"))) return true;
+
+  QString helperDir = QFileInfo(readProcExe(getpid())).canonicalPath();
+  return !helperDir.isEmpty()
+      && QFileInfo(realPath).canonicalPath() == helperDir
+      && isDirOwnerWritableOnly(helperDir);
 }
 
 /*

--- a/notifier/main.cpp
+++ b/notifier/main.cpp
@@ -52,9 +52,9 @@ int main(int argc, char *argv[])
     return (-2);
   }
 
-  if (!QFile::exists(ctn_OCTOPI_HELPER_PATH))
+  if (!QFile::exists(UnixCommand::getOctopiHelperPath()))
   {
-    qDebug() << "Aborting notifier as 'octphelper' binary could not be found! [" << ctn_OCTOPI_HELPER_PATH << "]";
+    qDebug() << "Aborting notifier as 'octphelper' binary could not be found! [" << UnixCommand::getOctopiHelperPath() << "]";
     return (-3);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,9 +36,9 @@ int main(int argc, char *argv[])
     return (-1);
   }
 
-  if (!QFile::exists(ctn_OCTOPI_HELPER_PATH))
+  if (!QFile::exists(UnixCommand::getOctopiHelperPath()))
   {
-    qDebug() << "Aborting octopi as 'octphelper' binary could not be found! [" << ctn_OCTOPI_HELPER_PATH << "]";
+    qDebug() << "Aborting octopi as 'octphelper' binary could not be found! [" << UnixCommand::getOctopiHelperPath() << "]";
     return (-2);
   }
 

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -78,7 +78,7 @@ void Terminal::runOctopiHelperInTerminalWithSharedMem(const QStringList &command
   if (removedLines) out += QLatin1String("echo \"") + StrConstants::getPressAnyKey() + QLatin1String("\"");
   out.remove(QLatin1String(";"));
 
-  QString commandToRun = ctn_OCTOPI_HELPER_PATH + QLatin1String(" -ts");
+  QString commandToRun = UnixCommand::getOctopiHelperPath() + QLatin1String(" -ts");
   QString cmd = getSudoProgram() + QLatin1String(" ") + commandToRun;
   QByteArray sharedData=out.toLatin1();
 

--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -729,6 +729,16 @@ QString UnixCommand::findExecutable(const QString& exeName)
 }
 
 /*
+ * Prefer a sibling octphelper next to the running binary so dev builds
+ * use their own helper; fall back to the system-installed path.
+ */
+QString UnixCommand::getOctopiHelperPath()
+{
+  const QString sibling = QCoreApplication::applicationDirPath() + QStringLiteral("/octphelper");
+  return QFile::exists(sibling) ? sibling : ctn_OCTOPI_HELPER_PATH;
+}
+
+/*
  * Checks if the given executable is available somewhere in the system
  */
 bool UnixCommand::hasTheExecutable(const QString& exeName)
@@ -1074,7 +1084,7 @@ void UnixCommand::executeCommandWithSharedMemHelper(const QString &pCommand, QSh
 
   QStringList sl;
   sl << ctn_QTSUDO_PARAMS;
-  sl << ctn_OCTOPI_HELPER_PATH << QStringLiteral("-ts");
+  sl << getOctopiHelperPath() << QStringLiteral("-ts");
   m_process->start(WMHelper::getSUCommand(), sl);
 }
 
@@ -1187,7 +1197,7 @@ int UnixCommand::cancelProcess(QSharedMemory *sharedMem)
   buildOctopiHelperCommandWithSharedMem(pCommand, sharedMem);
   QStringList sl;
   sl << ctn_QTSUDO_PARAMS;
-  sl << ctn_OCTOPI_HELPER_PATH << QStringLiteral("-ts");
+  sl << getOctopiHelperPath() << QStringLiteral("-ts");
   pacman.start(WMHelper::getSUCommand(), sl);
   pacman.waitForFinished(-1);
   return pacman.exitCode();
@@ -1219,10 +1229,13 @@ bool UnixCommand::isAppRunning(const QString &appName, bool justOneInstance)
 }
 
 /*
- * Checks if Octopi/Octopi-notifier, cache-cleaner, etc is being executed from /usr/bin
+ * Checks if Octopi/Octopi-notifier, cache-cleaner, etc is being executed from allowed paths
+ * Allowed paths can be configured via OCTOPI_ALLOWED_PATHS environment variable (colon-separated)
+ * Default: /usr/bin only (security: only system-installed binaries are trusted)
+ * Development: set OCTOPI_ALLOWED_PATHS=/usr/bin:/path/to/your/build to allow running from build dir
  */
 bool UnixCommand::isOctoToolRunning(const QString &octoToolName)
-{  
+{
   char exePath[PATH_MAX];
   ssize_t count = readlink("/proc/self/exe", exePath, sizeof(exePath));
   if (count == -1)
@@ -1233,6 +1246,18 @@ bool UnixCommand::isOctoToolRunning(const QString &octoToolName)
 
   QString path = QString::fromUtf8(exePath, count);
   QFileInfo fi(path);
+
+  QByteArray allowedPathsEnv = qgetenv("OCTOPI_ALLOWED_PATHS");
+  if (!allowedPathsEnv.isEmpty())
+  {
+    QStringList allowedPaths = QString::fromUtf8(allowedPathsEnv).split(QLatin1Char(':'), Qt::SkipEmptyParts);
+    for (const QString &allowedPath : allowedPaths)
+    {
+      if (fi.absoluteFilePath() == allowedPath + QLatin1Char('/') + octoToolName)
+        return true;
+    }
+    return false;
+  }
 
   return (fi.absoluteFilePath() == QLatin1String("/usr/bin/") + octoToolName);
 }
@@ -1653,7 +1678,8 @@ bool UnixCommand::isOctopiHelperRunning()
   if (out.contains(QLatin1String("|"))) return false;
   out=out.remove(QStringLiteral("\n"));
   out=out.remove(QStringLiteral("COMMAND"));
-  if ((out == QLatin1String("/usr/lib/octopi/") + octoToolName) || out.contains(QLatin1String("/usr/lib/octopi/") + octoToolName + QLatin1String(" "))) res=true;
+  const QString helperPath = getOctopiHelperPath();
+  if (out == helperPath || out.contains(helperPath + QLatin1Char(' '))) res=true;
 
   return res;
 }

--- a/src/unixcommand.h
+++ b/src/unixcommand.h
@@ -112,6 +112,7 @@ public:
   static bool isTextFile(QString fileName); //fileName is Path + Name
 
   static QString findExecutable( const QString& exeName );
+  static QString getOctopiHelperPath();
   static bool hasTheExecutable( const QString& exeName );
   static bool isAppRunning(const QString &appName, bool justOneInstance = false);
 


### PR DESCRIPTION
Refreshed against current `master`. Most of the original PR is already upstream, thanks for picking that up. What's left is the Nix-specific stuff plus the small extras needed to make a build from `build/` work end to end (including install / upgrade / remove). Distro installs are untouched.

This PR adds Nix flake support to enable clean, isolated development without installing dependencies system-wide.

[Screencast_20251116_134654.webm](https://github.com/user-attachments/assets/c7859111-ae84-44ff-a8c4-dee5c839a568)

## Motivation

Building Octopi currently requires manually cloning and installing `alpm_octopi_utils`, `qt-sudo`, Qt6 libraries, vala, and other tools system-wide. This makes it difficult to test changes without replacing your system installation of Octopi, pollutes the system with development dependencies, etc. The flake provides isolated, reproducible builds with all dependencies managed automatically in a dev shell with Qt6, CMake, vala, and friends. It builds `alpm_octopi_utils` and `qt-sudo` from source and sets up the env so you can build with CMake or qmake just like the existing instructions.

## Quick start

```bash
# Install Nix if needed
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install

git clone https://github.com/aarnt/octopi
cd octopi
nix develop
mkdir -p build && cd build
cmake .. -DCMAKE_BUILD_TYPE=Release
make -j$(nproc)
./octopi
```

Optional: `echo 'use flake' > .envrc` for direnv.

## Code changes

These are the minimum needed to let an Octopi running from `build/` work end to end without changing anything for `/usr/bin/octopi`.

1. `src/unixcommand.cpp::isOctoToolRunning()`: accept allowed paths from an `OCTOPI_ALLOWED_PATHS` env var. The dev shell sets it to `/usr/bin:<repo>/build`. If unset, the original `/usr/bin/<tool>` check is used unchanged.

2. `src/unixcommand.{cpp,h}::getOctopiHelperPath()`: prefer a sibling `octphelper` next to the running binary, fall back to `ctn_OCTOPI_HELPER_PATH`. For a distro install the fallback wins bit for bit (no `/usr/bin/octphelper` exists). For a dev build the sibling exists. Updates the helper-existence checks in `main.cpp`, `notifier/main.cpp`, `cachecleaner/main.cpp`, the qt-sudo invocations in `src/unixcommand.cpp`, the in-terminal helper command in `src/terminal.cpp`, and the TCP handshake recognition in `isOctopiHelperRunning()`.

3. `helper/octopihelper.cpp::isProcessRunningFromPath()`: widen the trusted path set from "starts with `/usr/bin`" to also accept callers co-located with the helper itself, provided the helper's directory is not group- or world-writable. Same path-based trust the existing check already uses (integrity from filesystem permissions on the trusted dir). Distro install trusted dir is `/usr/lib/octopi/`, owned by root, no change. Dev build trusted dir is the build dir, owned by the user who is already typing their qt-sudo password to invoke the helper, so no new escalation primitive.

No env vars are passed to the helper, no sudoers tweaks required.

All existing build methods (`qmake`, `CMake`, `PKGBUILD`) continue to work unchanged.

## What I tested

On Arch (CachyOS, pacman 7.1.0 / libalpm 16.0.1), with the system `octopi` 0.19.0-1 package installed in parallel.

Inside `nix develop` from `build/`:

- `cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)` produces `octopi`, `octopi-notifier`, `octopi-cachecleaner`, `octopi-repoeditor`, `octphelper`.
- `./build/octopi` launches.
- "Check updates" (Ctrl+K) prompts via qt-sudo and reports outdated packages correctly.
- Installing `htop` from the UI succeeds. `/usr/lib/octopi/octphelper.log` shows `Path of PID ... is <repo>/build/octopi` and `Exec as root: /usr/bin/pacman -S --noconfirm ... htop`.
- Removing `htop` from the UI succeeds (same log pattern, `pacman -R`).
- System upgrade from the UI runs to completion.

Negative case:

- `env -u OCTOPI_ALLOWED_PATHS ./build/octopi` shows the existing `You must use "/usr/bin/octopi" to run Octopi` popup and exits 251. Gate unchanged when the env var is not set.

Distro install path:

- `/usr/bin/octopi` (system package) still launches and performs transactions normally, without reading `OCTOPI_ALLOWED_PATHS` and with `getOctopiHelperPath()` falling through to `/usr/lib/octopi/octphelper`.

`git status` after `nix build` is clean (`result/` is gitignored).
