### PR TITLE
Make `xdg-open` the Primary Choice  for `Open PKGBUILD`

### DIFF
--- a/src/wmhelper.cpp
+++ b/src/wmhelper.cpp
@@ -388,7 +388,14 @@ void WMHelper::editFile(const QString& fileName, EditOptions opt)
   QString p;
 
   LinuxDistro distro = UnixCommand::getLinuxDistro();
-  if (distro == ectn_ARCHBANGLINUX && UnixCommand::hasTheExecutable(ctn_ARCHBANG_EDITOR))
+  
+  // Check for xdg-open first (respects user's default editor and environment variables)
+  if (UnixCommand::hasTheExecutable(ctn_XDG_OPEN))
+  {
+    p = ctn_XDG_OPEN + QLatin1Char(' ') + fileName;
+  }
+  // Fall back to DE-specific editors if xdg-open isn't available
+  else if (distro == ectn_ARCHBANGLINUX && UnixCommand::hasTheExecutable(ctn_ARCHBANG_EDITOR))
   {
     p = ctn_ARCHBANG_EDITOR + QLatin1Char(' ') + fileName;
   }
@@ -431,10 +438,6 @@ void WMHelper::editFile(const QString& fileName, EditOptions opt)
   }
   else if (UnixCommand::hasTheExecutable(ctn_XFCE_EDITOR) || UnixCommand::hasTheExecutable(ctn_XFCE_EDITOR_ALT)){
     p = getXFCEEditor() + QLatin1Char(' ') + fileName;
-  }
-  else if (UnixCommand::hasTheExecutable(ctn_XDG_OPEN))
-  {
-    p = ctn_XDG_OPEN + QLatin1Char(' ') + fileName;
   }
 
   if (opt == ectn_EDIT_AS_NORMAL_USER && !p.isEmpty())


### PR DESCRIPTION
This will respect the user's default applications and environment variables.

Benefits of Using xdg-open:
- Respects user preferences through mimeapps.list
- Honors `EDITOR` environment variable for text files
- Desktop-agnostic - works across all environments
- Follows XDG standards for proper integration

As a reminder:
Octopi does NOT use the EDITOR or VISUAL environment variables for editor Selection. instead it determines which editor to use based on: Desktop Environment detection (KDE, GNOME, XFCE, LXQt, MATE, etc.) with a Fallback to xdg-open.

Changes Made:
- Moved xdg-open check to the top - Now it's the first option checked 
- Added explanatory comment - Documents that this respects user's default editor and environment variables
- Restructured the logic - All other desktop-specific editors are now fallback options

(I would say we could then even remove all of that code which becomes redundant)
