### PR TITLE
fix: add xdg-open fallback for openDirectory

### DIFF
--- a/src/wmhelper.cpp
+++ b/src/wmhelper.cpp
@@ -549,5 +549,10 @@ void WMHelper::openDirectory(const QString& dirName)
       s << dir;
       p->startDetached( ctn_GNOME_FILE_MANAGER, s );
     }
+    else if (UnixCommand::hasTheExecutable(ctn_XDG_OPEN))
+    {
+      s << dir;
+      p->startDetached( ctn_XDG_OPEN, s);
+    }
   }
 }


### PR DESCRIPTION
Fix openDirectory on Hyprland.

Or maybe better to use this patch instead?
```cpp
void WMHelper::openDirectory(const QString& dirName)
{
  QProcess *p = new QProcess(qApp->activeWindow());
  QStringList s;
  QString dir(dirName);

  //Is it really a directory?
  QFileInfo f(dirName);
  if (!f.isDir())
  {
    dir = f.absolutePath();
    f = QFileInfo(dir);
  }
  QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
}
```