### PR TITLE
Add a Comment to the notifier, cachecleaner and repoeditor desktop files

### DIFF
--- a/cachecleaner/octopi-cachecleaner.desktop
+++ b/cachecleaner/octopi-cachecleaner.desktop
@@ -1,5 +1,7 @@
 [Desktop Entry]
 Name=Octopi CacheCleaner
+Comment=Free disk space by removing old packages from the cache
+Comment[ru]=Удаление старых пакетов из кэша и освобождение места на диске
 Icon=octopi
 Exec=/usr/bin/octopi-cachecleaner
 Terminal=false

--- a/notifier/octopi-notifier.desktop
+++ b/notifier/octopi-notifier.desktop
@@ -1,5 +1,7 @@
 [Desktop Entry]
 Name=Octopi Notifier
+Comment=Get notified when package updates are available
+Comment[ru]=Уведомления о доступных обновлениях пакетов
 Icon=octopi
 Exec=/usr/bin/octopi-notifier
 Terminal=false

--- a/repoeditor/octopi-repoeditor.desktop
+++ b/repoeditor/octopi-repoeditor.desktop
@@ -1,5 +1,7 @@
 [Desktop Entry]
 Name=Octopi Repository Editor
+Comment=Manage the package repositories used by the system
+Comment[ru]=Настройка списка репозиториев пакетов
 Icon=octopi
 Exec=/usr/bin/octopi-repoeditor
 Terminal=false


### PR DESCRIPTION
Unlike octopi.desktop, the desktop files for the notifier, the cache cleaner and the repository editor have no Comment key at all, not even in English. In application menus that show a one-line description under the name (KDE Plasma, GNOME, Cinnamon...) these three entries are simply blank, which is a bit unfortunate for the repository editor and the cache cleaner since their names alone do not say much about what they do.

So this adds an English Comment to each of the three, kept short and in the same tone as the one in octopi.desktop, plus a Russian translation of it. The wording follows the terminology already used in the Russian .ts files of these tools ("репозиторий", "кэш пакетов"), so the menu and the applications say the same thing.

Nothing else is touched: no key is changed or removed, only Comment lines are added, so behaviour is identical for anyone whose menu does not display descriptions. All three files still pass desktop-file-validate cleanly. I ran it here on Arch with KDE Plasma 6 and a ru_RU locale, and the descriptions do show up in the menu.